### PR TITLE
fix: Google sign-in redirect flow (popup blocked by Safari/Edge)

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -126,53 +126,92 @@ export const login = async (req, res) => {
     }
 }
 
+// Shared by both the popup flow (googleLogin) and the redirect-fallback
+// flow (googleLoginCallback) — Safari's Intelligent Tracking Prevention and
+// Edge's Tracking Prevention both block the popup+iframe handshake GSI's
+// classic ux_mode:"popup" button relies on, so browsers that can't complete
+// that handshake fall back to a full-page redirect instead.
+const verifyAndUpsertGoogleUser = async (idToken) => {
+    if (!googleClient) {
+        const err = new Error("Google login is not configured on this server");
+        err.status = 501;
+        throw err;
+    }
+    if (!idToken) {
+        const err = new Error("idToken is required");
+        err.status = 400;
+        throw err;
+    }
+
+    const ticket = await googleClient.verifyIdToken({
+        idToken,
+        audience: process.env.GOOGLE_CLIENT_ID
+    });
+    const payload = ticket.getPayload();
+
+    let user = await User.findOne({ email: payload.email });
+    if (!user) {
+        const usernameBase = payload.email.split("@")[0].replace(/[^a-zA-Z0-9_]/g, "");
+        let username = usernameBase;
+        let suffix = 0;
+        while (await User.findOne({ username })) {
+            suffix += 1;
+            username = `${usernameBase}${suffix}`;
+        }
+        user = new User({
+            name: payload.name || usernameBase,
+            email: payload.email,
+            username,
+            googleId: payload.sub,
+            profilePicture: payload.picture || undefined,
+            // Google already verified this address — no OTP step needed.
+            emailVerified: true
+        });
+        await user.save();
+        await new Profile({ userId: user._id }).save();
+    } else if (!user.active) {
+        const err = new Error("This account has been suspended");
+        err.status = 403;
+        throw err;
+    } else if (!user.googleId || !user.emailVerified) {
+        user.googleId = user.googleId || payload.sub;
+        user.emailVerified = true;
+        await user.save();
+    }
+
+    return user;
+};
+
 export const googleLogin = async (req, res) => {
     try {
-        if (!googleClient) {
-            return res.status(501).json({ message: "Google login is not configured on this server" });
-        }
-        const { idToken } = req.body;
-        if (!idToken) return res.status(400).json({ message: "idToken is required" });
-
-        const ticket = await googleClient.verifyIdToken({
-            idToken,
-            audience: process.env.GOOGLE_CLIENT_ID
-        });
-        const payload = ticket.getPayload();
-
-        let user = await User.findOne({ email: payload.email });
-        if (!user) {
-            const usernameBase = payload.email.split("@")[0].replace(/[^a-zA-Z0-9_]/g, "");
-            let username = usernameBase;
-            let suffix = 0;
-            while (await User.findOne({ username })) {
-                suffix += 1;
-                username = `${usernameBase}${suffix}`;
-            }
-            user = new User({
-                name: payload.name || usernameBase,
-                email: payload.email,
-                username,
-                googleId: payload.sub,
-                profilePicture: payload.picture || undefined,
-                // Google already verified this address — no OTP step needed.
-                emailVerified: true
-            });
-            await user.save();
-            await new Profile({ userId: user._id }).save();
-        } else if (!user.active) {
-            return res.status(403).json({ message: "This account has been suspended" });
-        } else if (!user.googleId || !user.emailVerified) {
-            user.googleId = user.googleId || payload.sub;
-            user.emailVerified = true;
-            await user.save();
-        }
-
+        const user = await verifyAndUpsertGoogleUser(req.body.idToken);
         const accessToken = await issueSession(res, user);
         return res.json({ token: accessToken });
     } catch (error) {
         console.error("Google login error:", error.message);
-        return res.status(401).json({ message: "Invalid Google token" });
+        return res.status(error.status || 401).json({ message: error.status ? error.message : "Invalid Google token" });
+    }
+};
+
+// GSI's redirect ux_mode POSTs here as a real top-level navigation (form
+// submit), so it works even when the browser blocks the popup/iframe
+// handshake. Google also sets a g_csrf_token cookie alongside the POST body
+// field of the same name — matching them is how this endpoint tells a
+// genuine Google-initiated submission apart from a forged one, since a
+// third-party page can't read/set cookies on accounts.google.com's domain.
+export const googleLoginCallback = async (req, res) => {
+    const failUrl = `${process.env.FRONTEND_URL}/login?googleError=1`;
+    try {
+        const { credential, g_csrf_token } = req.body;
+        if (!g_csrf_token || g_csrf_token !== req.cookies?.g_csrf_token) {
+            return res.redirect(failUrl);
+        }
+        const user = await verifyAndUpsertGoogleUser(credential);
+        const accessToken = await issueSession(res, user);
+        return res.redirect(`${process.env.FRONTEND_URL}/login?googleToken=${accessToken}`);
+    } catch (error) {
+        console.error("Google login callback error:", error.message);
+        return res.redirect(failUrl);
     }
 };
 

--- a/backend/routes/user.routes.js
+++ b/backend/routes/user.routes.js
@@ -1,6 +1,6 @@
 
 import multer from "multer";
-import { acceptConnectionRequest, downloadProfile, findSearchUser, getAllUserBasedOnUsername, getMyConnectionRequest, getUserAndProfile, login, logout, register, sendconnectionrequest, updateProfileData, updateUserProfile, uploadCoverPhoto, uploadImage, uploadProfilePicture, whatAreMyConnection, searchUsers, getSuggestions, googleLogin, refreshAccessToken, deleteMyAccount, switchAccount } from "../controllers/user.controller.js";
+import { acceptConnectionRequest, downloadProfile, findSearchUser, getAllUserBasedOnUsername, getMyConnectionRequest, getUserAndProfile, login, logout, register, sendconnectionrequest, updateProfileData, updateUserProfile, uploadCoverPhoto, uploadImage, uploadProfilePicture, whatAreMyConnection, searchUsers, getSuggestions, googleLogin, googleLoginCallback, refreshAccessToken, deleteMyAccount, switchAccount } from "../controllers/user.controller.js";
 import { sendOtp, verifyOtp, resendOtp, resetPassword } from "../controllers/otp.controller.js";
 import { createReport } from "../controllers/admin.controller.js";
 import { Router } from "express"
@@ -16,6 +16,7 @@ router.route("/register").post(register);
 router.route('/login').post(login);
 router.route('/logout').post(logout);
 router.route('/auth/google').post(googleLogin);
+router.route('/auth/google/callback').post(googleLoginCallback);
 router.route('/auth/refresh').post(refreshAccessToken);
 router.route('/auth/send-otp').post(sendOtp);
 router.route('/auth/verify-otp').post(verifyOtp);

--- a/frontend/src/Components/ui/GoogleLoginButton.jsx
+++ b/frontend/src/Components/ui/GoogleLoginButton.jsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef } from 'react';
 
 const CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
 
-export default function GoogleLoginButton({ onCredential }) {
+export default function GoogleLoginButton() {
   const buttonRef = useRef(null);
 
   useEffect(() => {
@@ -11,7 +12,13 @@ export default function GoogleLoginButton({ onCredential }) {
     const renderButton = () => {
       window.google.accounts.id.initialize({
         client_id: CLIENT_ID,
-        callback: (response) => onCredential(response.credential),
+        // The classic popup+iframe handshake this library used to rely on
+        // gets silently blocked by Safari's Intelligent Tracking Prevention
+        // and Edge's Tracking Prevention ("Failed to open popup window").
+        // ux_mode:"redirect" is a real top-level navigation instead, so it
+        // isn't affected by popup blockers or third-party-cookie policies.
+        ux_mode: 'redirect',
+        login_uri: `${BACKEND_URL}/api/auth/google/callback`,
       });
       window.google.accounts.id.renderButton(buttonRef.current, {
         theme: 'outline',

--- a/frontend/src/config/redux/action/authAction/index.js
+++ b/frontend/src/config/redux/action/authAction/index.js
@@ -39,22 +39,6 @@ export const loginUser = createAsyncThunk(
         }
     }
 )
-export const googleLoginUser = createAsyncThunk(
-    "user/googleLogin",
-    async (idToken, thunkApi) => {
-        try {
-            const response = await clientServer.post('/auth/google', { idToken })
-            if (response.data.token)
-                startNewSession(response.data.token);
-            else
-                return thunkApi.rejectWithValue({ message: "token not provided" })
-            return thunkApi.fulfillWithValue(response.data.token)
-        } catch (error) {
-            return thunkApi.rejectWithValue(error.response?.data || { message: "Google login failed" })
-        }
-    }
-)
-
 export const registerUser = createAsyncThunk(
     "user/register",
     async (user, thunkApi) => {

--- a/frontend/src/config/redux/reducer/authReducer/index.js
+++ b/frontend/src/config/redux/reducer/authReducer/index.js
@@ -1,5 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { getAboutUser, loginUser, googleLoginUser, registerUser, getAllUser, getConnectionRequest, getMyConnectionRequests, acceptConnectionRequest, downloadResume, updateUserProfile, logout, verifyOtp, resendOtp, sendOtp, resetPasswordAction, deleteAccount, switchAccountAction } from "../../action/authAction/index";
+import { getAboutUser, loginUser, registerUser, getAllUser, getConnectionRequest, getMyConnectionRequests, acceptConnectionRequest, downloadResume, updateUserProfile, logout, verifyOtp, resendOtp, sendOtp, resetPasswordAction, deleteAccount, switchAccountAction } from "../../action/authAction/index";
 import { rememberAccount } from "../../../savedAccounts";
 
 
@@ -59,23 +59,6 @@ const authSlice = createSlice({
                 state.isLoading = false
                 state.isError = true
                 state.message = action.payload.message || 'Login failed';
-            })
-            .addCase(googleLoginUser.pending, (state) => {
-                state.isLoading = true
-                state.message = "signing in with Google"
-            })
-            .addCase(googleLoginUser.fulfilled, (state) => {
-                state.isLoading = false
-                state.isSuccess = true
-                state.isError = false
-                state.loggedIn = true
-                state.isTokenThere = true
-                state.message = "Login successful"
-            })
-            .addCase(googleLoginUser.rejected, (state, action) => {
-                state.isLoading = false
-                state.isError = true
-                state.message = action.payload?.message || 'Google login failed';
             })
             .addCase(registerUser.pending, (state) => {
                 state.isLoading = true

--- a/frontend/src/pages/login/index.jsx
+++ b/frontend/src/pages/login/index.jsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router'
 import React, { useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import styles from './styles.module.css'
-import { loginUser, registerUser, googleLoginUser, verifyOtp, resendOtp, switchAccountAction } from '@/config/redux/action/authAction'
+import { loginUser, registerUser, verifyOtp, resendOtp, switchAccountAction, getAboutUser } from '@/config/redux/action/authAction'
 import { emptyMessage } from '@/config/redux/reducer/authReducer'
 import { getSavedAccounts } from '@/config/savedAccounts'
 import Button from '@/Components/ui/Button'
@@ -45,6 +45,23 @@ function LoginComponent() {
     resendTimerRef.current = setTimeout(() => setResendIn((s) => s - 1), 1000);
     return () => clearTimeout(resendTimerRef.current);
   }, [resendIn]);
+
+  // Google sign-in now completes via a full-page redirect (see
+  // GoogleLoginButton) rather than a popup, so the result lands here as
+  // query params instead of a JS callback.
+  const [googleAuthError, setGoogleAuthError] = useState(false);
+  useEffect(() => {
+    if (!router.isReady) return;
+    if (router.query.googleToken) {
+      localStorage.setItem("token", String(router.query.googleToken));
+      localStorage.removeItem("recentSearches");
+      dispatch(getAboutUser());
+      router.replace('/dashboard');
+    } else if (router.query.googleError) {
+      setGoogleAuthError(true);
+      router.replace('/login', undefined, { shallow: true });
+    }
+  }, [router.isReady, router.query.googleToken, router.query.googleError]);
 
   useEffect(() => {
     const token = localStorage.getItem("token");
@@ -173,6 +190,11 @@ function LoginComponent() {
             {authState.message && (
               <div className={`text-sm mb-2.5 font-medium ${authState.isError ? 'text-danger' : 'text-success'}`}>
                 {authState.message}
+              </div>
+            )}
+            {googleAuthError && (
+              <div className="text-sm mb-2.5 font-medium text-danger">
+                Google sign-in failed. Please try again.
               </div>
             )}
 
@@ -305,14 +327,7 @@ function LoginComponent() {
                 <span className="flex-1 h-px bg-gray-200" />
               </div>
 
-              <GoogleLoginButton
-                onCredential={async (idToken) => {
-                  const result = await dispatch(googleLoginUser(idToken));
-                  if (googleLoginUser.fulfilled.match(result)) {
-                    router.push('/dashboard');
-                  }
-                }}
-              />
+              <GoogleLoginButton />
             </div>
             )}
           </div>


### PR DESCRIPTION
## Summary
- Switches Google Sign-In from the popup+iframe flow to ux_mode:"redirect", since the popup handshake was being blocked by Safari ITP and Edge Tracking Prevention in real testing.
- Backend: new POST /api/auth/google/callback handles the redirect-mode form POST with CSRF cookie validation.
- Frontend: login page picks the token up from the redirect query param.

## Test plan
- [ ] Click "Sign in with Google" on production, confirm full-page redirect through Google and back to /dashboard logged in
- [ ] Confirm this works in Safari and Edge specifically (the browsers that failed before)