### PR TITLE
fix: remove stale onCredential ref crashing login page

### DIFF
--- a/frontend/src/Components/ui/GoogleLoginButton.jsx
+++ b/frontend/src/Components/ui/GoogleLoginButton.jsx
@@ -38,7 +38,7 @@ export default function GoogleLoginButton() {
     script.async = true;
     script.onload = renderButton;
     document.body.appendChild(script);
-  }, [onCredential]);
+  }, []);
 
   if (!CLIENT_ID) {
     return (


### PR DESCRIPTION
Leftover dependency-array reference from the redirect-flow migration was throwing a ReferenceError on every /login page load.