### PR TITLE
fix: call UI scroll-lock + minimize, online status in My Network

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # macOS
 .DS_Store
 
+# Vercel CLI local project link (no secrets, just a project ID) — regenerate
+# with `vercel link` rather than committing.
+.vercel
+
 # Design handoff/reference material — not app source, not needed in the repo
 design_handoff_mitrata_redesign/
 design_handoff_mitrata_redesign 2/

--- a/frontend/src/Components/CallProvider/Call.module.css
+++ b/frontend/src/Components/CallProvider/Call.module.css
@@ -23,6 +23,7 @@
 }
 
 .callCard {
+    position: relative;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -34,6 +35,94 @@
     box-shadow: var(--mt-shadow-lg);
     width: 100%;
     max-width: 340px;
+}
+
+.minimizeBtn {
+    position: absolute;
+    top: 14px;
+    right: 14px;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 1px solid var(--mt-border);
+    background: var(--mt-sunken);
+    color: var(--mt-ink2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    z-index: 2;
+}
+
+.videoStage .minimizeBtn {
+    top: 16px;
+    right: 16px;
+    background: rgba(0, 0, 0, 0.45);
+    border-color: rgba(255, 255, 255, 0.2);
+    color: #fff;
+}
+
+/* Minimized call bubble — same idea as a browser's native PiP window: stays
+   visible over whatever page you navigate to, without blocking scroll or
+   interaction with the rest of the app underneath. */
+.miniBubble {
+    position: fixed;
+    right: 16px;
+    bottom: 88px;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    border-radius: 999px;
+    background: var(--mt-surface);
+    border: 1px solid var(--mt-border);
+    box-shadow: var(--mt-shadow-lg);
+    cursor: pointer;
+    max-width: 240px;
+    animation: fadeIn 0.2s var(--mt-ease);
+}
+
+.miniAvatar {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    object-fit: cover;
+    flex-shrink: 0;
+}
+
+.miniInfo {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.miniName {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--mt-ink);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.miniStatus {
+    font-size: 11.5px;
+    color: var(--mt-ink3);
+}
+
+.miniEndBtn {
+    flex-shrink: 0;
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    border: none;
+    background: var(--mt-danger);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
 }
 
 .overline {

--- a/frontend/src/Components/CallProvider/CallOverlay.jsx
+++ b/frontend/src/Components/CallProvider/CallOverlay.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Phone, PhoneOff, Mic, MicOff, Video, VideoOff } from 'lucide-react';
+import { Phone, PhoneOff, Mic, MicOff, Video, VideoOff, Minimize2 } from 'lucide-react';
 import styles from './Call.module.css';
 
 function formatDuration(seconds) {
@@ -23,15 +23,48 @@ export default function CallOverlay({
     onEnd,
     onToggleMute,
     onToggleVideo,
+    isMinimized,
+    onMinimize,
+    onExpand,
 }) {
     const isPulsing = callState === 'calling' || callState === 'ringing';
     const isConnecting = callState !== 'active';
+
+    // Minimized: a small floating bubble (same idea as a browser's native
+    // PiP window) — lets you keep using the app underneath instead of the
+    // call pinning you to a full-screen modal until it ends.
+    if (isMinimized) {
+        return (
+            <div className={styles.miniBubble} onClick={onExpand} role="button" tabIndex={0} aria-label="Expand call">
+                <img src={remoteUser?.avatar || '/default-avatar.svg'} alt="" className={styles.miniAvatar} />
+                <div className={styles.miniInfo}>
+                    <span className={styles.miniName}>{remoteUser?.name || 'Unknown'}</span>
+                    <span className={styles.miniStatus}>
+                        {callState === 'active' ? formatDuration(callDuration) : callState === 'ringing' ? 'Incoming…' : 'Calling…'}
+                    </span>
+                </div>
+                <button
+                    className={styles.miniEndBtn}
+                    onClick={(e) => { e.stopPropagation(); onEnd(); }}
+                    aria-label="End call"
+                >
+                    <PhoneOff size={16} strokeWidth={2} />
+                </button>
+            </div>
+        );
+    }
 
     if (isVideoCall) {
         return (
             <div className={styles.overlay}>
                 <div className={styles.videoStage}>
                     <video ref={remoteVideoRef} className={styles.remoteVideo} autoPlay playsInline />
+
+                    {callState !== 'ringing' && (
+                        <button className={styles.minimizeBtn} onClick={onMinimize} aria-label="Minimize call">
+                            <Minimize2 size={18} strokeWidth={2} />
+                        </button>
+                    )}
 
                     {isConnecting && (
                         <div className={styles.videoConnectingScrim}>
@@ -100,6 +133,11 @@ export default function CallOverlay({
         <div className={styles.overlay}>
             <div className={styles.callCard}>
                 <span className={styles.overline}>Voice call</span>
+                {callState !== 'ringing' && (
+                    <button className={styles.minimizeBtn} onClick={onMinimize} aria-label="Minimize call">
+                        <Minimize2 size={18} strokeWidth={2} />
+                    </button>
+                )}
 
                 {/* Avatar */}
                 <div className={styles.avatarRing}>

--- a/frontend/src/Components/CallProvider/index.jsx
+++ b/frontend/src/Components/CallProvider/index.jsx
@@ -61,6 +61,7 @@ export function CallProvider({ children }) {
     const [remoteRinging, setRemoteRinging] = useState(false);
     const [isVideoCall, setIsVideoCall] = useState(false);
     const [isVideoOff, setIsVideoOff] = useState(false);
+    const [isMinimized, setIsMinimized] = useState(false);
 
     // ... (refs same as before)
     const peerConnection = useRef(null);
@@ -115,7 +116,18 @@ export function CallProvider({ children }) {
         setRemoteRinging(false);
         setIsVideoCall(false);
         setIsVideoOff(false);
+        setIsMinimized(false);
     }, []);
+
+    // The full overlay is a real modal (you shouldn't be able to scroll the
+    // page underneath while it's up); minimizing it is the escape hatch —
+    // same idea as a browser's native PiP window for an ongoing call — so
+    // the page becomes scrollable again as soon as it's not full-screen.
+    useEffect(() => {
+        const shouldLock = callState !== 'idle' && !isMinimized;
+        document.body.style.overflow = shouldLock ? 'hidden' : '';
+        return () => { document.body.style.overflow = ''; };
+    }, [callState, isMinimized]);
 
     const createPeerConnection = useCallback((targetUserId) => {
         const pc = new RTCPeerConnection(ICE_SERVERS);
@@ -426,7 +438,7 @@ export function CallProvider({ children }) {
     return (
         <CallContext.Provider value={{
             callUser, endCall, callState, remoteUser, isMuted, toggleMute, callDuration, remoteRinging,
-            isVideoCall, isVideoOff, toggleVideo,
+            isVideoCall, isVideoOff, toggleVideo, isMinimized,
         }}>
             {children}
             {/* Remote audio track always plays here — for video calls the same
@@ -451,6 +463,9 @@ export function CallProvider({ children }) {
                     onEnd={endCall}
                     onToggleMute={toggleMute}
                     onToggleVideo={toggleVideo}
+                    isMinimized={isMinimized}
+                    onMinimize={() => setIsMinimized(true)}
+                    onExpand={() => setIsMinimized(false)}
                 />
             )}
         </CallContext.Provider>

--- a/frontend/src/pages/my_network/index.jsx
+++ b/frontend/src/pages/my_network/index.jsx
@@ -14,7 +14,7 @@ export default function MyNetwork() {
     const dispatch = useDispatch();
     const authState = useSelector((state) => state.auth);
     const router = useRouter();
-    const { socketInstance } = useNotification();
+    const { socketInstance, onlineUsers } = useNotification();
 
     const [activeTab, setActiveTab] = useState('connections');
     const [isMounted, setIsMounted] = useState(false);
@@ -135,6 +135,7 @@ export default function MyNetwork() {
                                         <div key={conn._id} className={`${styles.userCard} mt-enter-sm`} style={{ animationDelay: `${idx * 60}ms` }}>
                                             <div className={styles.avatarRing}>
                                                 <img src={conn.userId.profilePicture || "/default-avatar.svg"} alt="profile" />
+                                                <span className={`${styles.onlineStatus} ${onlineUsers.has(conn.userId._id) ? styles.online : styles.offline}`} />
                                             </div>
                                             <div className={styles.userInfo} onClick={() => router.push(`/view_profile/${conn.userId.username}`)}>
                                                 <h4>{conn.userId.name}</h4>

--- a/frontend/src/pages/my_network/mynetwork.module.css
+++ b/frontend/src/pages/my_network/mynetwork.module.css
@@ -105,12 +105,31 @@
 }
 
 .avatarRing {
+    position: relative;
     flex-shrink: 0;
     width: 48px;
     height: 48px;
     border-radius: 50%;
     padding: 2px;
     background: var(--mt-grad);
+}
+
+.onlineStatus {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    border: 2px solid var(--mt-surface);
+}
+
+.onlineStatus.online {
+    background: var(--mt-online);
+}
+
+.onlineStatus.offline {
+    background: var(--mt-ink3);
 }
 
 .avatarRing img {


### PR DESCRIPTION
## Summary
- Call overlay now locks background scroll (real modal), with a new minimize control that collapses into a small floating bubble (like browser PiP) so you can keep using the app mid-call.
- My Network connections show live online/offline status, reusing the existing platform-wide presence tracking.

## Test plan
- [ ] Start a call, confirm the page behind the overlay can't scroll
- [ ] Minimize a call, confirm the bubble stays visible while navigating and the page scrolls normally
- [ ] Confirm My Network shows correct online dots for connected users