### PR TITLE
fix: cross-site refresh cookie (SameSite=Lax) silently dropped in prod

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -23,7 +23,7 @@ import Report from "../models/report.model.js";
 import ConvertUserDataToPdf from "./PdfFormat.js";
 import { escapeRegex } from "../utils/regex.js";
 import { issueOtp } from "./otp.controller.js";
-import { issueSession, hashToken, refreshCookieName } from "../utils/session.js";
+import { issueSession, hashToken, refreshCookieName, refreshCookieOptions } from "../utils/session.js";
 
 const googleClient = process.env.GOOGLE_CLIENT_ID ? new OAuth2Client(process.env.GOOGLE_CLIENT_ID) : null;
 
@@ -242,7 +242,7 @@ export const logout = async (req, res) => {
         const { userId } = req.body || {};
         if (userId) {
             await User.findByIdAndUpdate(userId, { refreshTokenHash: null });
-            res.clearCookie(refreshCookieName(userId), { path: "/api" });
+            res.clearCookie(refreshCookieName(userId), refreshCookieOptions());
         }
         return res.json({ message: "Logged out successfully" });
     } catch (error) {
@@ -267,17 +267,17 @@ export const switchAccount = async (req, res) => {
         try {
             decoded = jwt.verify(token, process.env.JWT_REFRESH_SECRET || process.env.JWT_SECRET);
         } catch {
-            res.clearCookie(cookieName, { path: "/api" });
+            res.clearCookie(cookieName, refreshCookieOptions());
             return res.status(401).json({ message: "Session expired, please log in again", needsLogin: true });
         }
 
         const user = await User.findById(decoded.userId);
         if (!user || !user.active) {
-            res.clearCookie(cookieName, { path: "/api" });
+            res.clearCookie(cookieName, refreshCookieOptions());
             return res.status(401).json({ message: "Account unavailable", needsLogin: true });
         }
         if (user.refreshTokenHash !== hashToken(token)) {
-            res.clearCookie(cookieName, { path: "/api" });
+            res.clearCookie(cookieName, refreshCookieOptions());
             return res.status(401).json({ message: "Session expired, please log in again", needsLogin: true });
         }
 
@@ -911,7 +911,7 @@ export const deleteMyAccount = async (req, res) => {
 
         await User.deleteOne({ _id: userId });
 
-        res.clearCookie("refreshToken", { path: "/api" });
+        res.clearCookie("refreshToken", refreshCookieOptions());
         return res.json({ message: "Account permanently deleted" });
     } catch (error) {
         console.error("Delete account error:", error);

--- a/backend/utils/session.js
+++ b/backend/utils/session.js
@@ -24,13 +24,27 @@ const hashToken = (token) => crypto.createHash("sha256").update(token).digest("h
 // cookie is still there and unexpired, otherwise it's a normal re-login.
 export const refreshCookieName = (userId) => `rt_${userId}`;
 
+// Frontend (vercel.app) and backend (onrender.com) are different sites in
+// production — a genuinely cross-site relationship, not just cross-port
+// like local dev. SameSite=Lax cookies are never attached to cross-site
+// XHR/fetch (only top-level GET navigations), so every /auth/refresh call
+// silently carried no cookie at all once the 15-minute access token expired,
+// bouncing the user to login. SameSite=None (paired with Secure, required
+// alongside it) is what actually lets a cross-site XHR send this cookie;
+// local dev stays "lax" since localhost:PORT is same-site regardless of port.
+const isCrossSiteDeploy = process.env.NODE_ENV === "production";
+
+export const refreshCookieOptions = () => ({
+    httpOnly: true,
+    secure: isCrossSiteDeploy,
+    sameSite: isCrossSiteDeploy ? "none" : "lax",
+    path: "/api"
+});
+
 const setRefreshCookie = (res, refreshToken, userId) => {
     res.cookie(refreshCookieName(userId), refreshToken, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
-        sameSite: "lax",
-        maxAge: REFRESH_TOKEN_TTL_MS,
-        path: "/api"
+        ...refreshCookieOptions(),
+        maxAge: REFRESH_TOKEN_TTL_MS
     });
 };
 


### PR DESCRIPTION
Refresh cookie was SameSite=Lax, which is never sent on cross-site XHR (only top-level GET) — broken the moment frontend/backend are on different domains in production. Switched to SameSite=None+Secure for the cross-site deploy case, kept Lax for local dev. This is why users were getting logged out mid-session and switch-account was silently failing.