### PR TITLE
fix: caller local video, minimize video unmount, blank page-load flash

### DIFF
--- a/frontend/src/Components/CallProvider/Call.module.css
+++ b/frontend/src/Components/CallProvider/Call.module.css
@@ -287,6 +287,30 @@
     background: #000;
 }
 
+/* Minimized video call — same PiP idea as the voice call's miniBubble, but
+   keeps the actual <video> element alive and playing instead of swapping it
+   out for different markup (see the comment in CallOverlay.jsx for why). */
+.overlayMinimized {
+    inset: auto;
+    right: 16px;
+    bottom: 88px;
+    left: auto;
+    top: auto;
+    background: none;
+    display: block;
+    animation: none;
+    pointer-events: none;
+}
+
+.videoStageMinimized {
+    width: 160px;
+    aspect-ratio: 3 / 4;
+    border-radius: 16px;
+    cursor: pointer;
+    box-shadow: var(--mt-shadow-lg);
+    pointer-events: auto;
+}
+
 .videoConnectingScrim {
     position: absolute;
     inset: 0;

--- a/frontend/src/Components/CallProvider/CallOverlay.jsx
+++ b/frontend/src/Components/CallProvider/CallOverlay.jsx
@@ -30,10 +30,11 @@ export default function CallOverlay({
     const isPulsing = callState === 'calling' || callState === 'ringing';
     const isConnecting = callState !== 'active';
 
-    // Minimized: a small floating bubble (same idea as a browser's native
-    // PiP window) — lets you keep using the app underneath instead of the
-    // call pinning you to a full-screen modal until it ends.
-    if (isMinimized) {
+    // Voice calls have no <video> element in play at all — the audio element
+    // that actually carries the call lives outside CallOverlay, unconditionally
+    // mounted in CallProvider, so swapping this markup out for a bubble on
+    // minimize is safe here (nothing gets unmounted that the call depends on).
+    if (isMinimized && !isVideoCall) {
         return (
             <div className={styles.miniBubble} onClick={onExpand} role="button" tabIndex={0} aria-label="Expand call">
                 <img src={remoteUser?.avatar || '/default-avatar.svg'} alt="" className={styles.miniAvatar} />
@@ -55,18 +56,30 @@ export default function CallOverlay({
     }
 
     if (isVideoCall) {
+        // Minimizing a video call must NEVER unmount these <video> elements —
+        // that was the actual bug (video going blank on minimize/expand):
+        // .srcObject is a property of that specific DOM node, so once it's
+        // gone, remounting a fresh <video> later has no stream attached and
+        // nothing re-attaches it. Minimizing here is purely a CSS shrink of
+        // the same persistent elements instead of swapping in different markup.
         return (
-            <div className={styles.overlay}>
-                <div className={styles.videoStage}>
+            <div className={`${styles.overlay} ${isMinimized ? styles.overlayMinimized : ''}`}>
+                <div
+                    className={`${styles.videoStage} ${isMinimized ? styles.videoStageMinimized : ''}`}
+                    onClick={isMinimized ? onExpand : undefined}
+                    role={isMinimized ? 'button' : undefined}
+                    tabIndex={isMinimized ? 0 : undefined}
+                    aria-label={isMinimized ? 'Expand call' : undefined}
+                >
                     <video ref={remoteVideoRef} className={styles.remoteVideo} autoPlay playsInline />
 
-                    {callState !== 'ringing' && (
+                    {!isMinimized && callState !== 'ringing' && (
                         <button className={styles.minimizeBtn} onClick={onMinimize} aria-label="Minimize call">
                             <Minimize2 size={18} strokeWidth={2} />
                         </button>
                     )}
 
-                    {isConnecting && (
+                    {!isMinimized && isConnecting && (
                         <div className={styles.videoConnectingScrim}>
                             <div className={styles.avatarRing}>
                                 <div className={styles.pulseRing} />
@@ -80,7 +93,7 @@ export default function CallOverlay({
                         </div>
                     )}
 
-                    {!isConnecting && (
+                    {!isMinimized && !isConnecting && (
                         <div className={styles.videoNameChip}>
                             <img src={remoteUser?.avatar || '/default-avatar.svg'} alt="" />
                             <span>{remoteUser?.name || 'Unknown'}</span>
@@ -88,42 +101,53 @@ export default function CallOverlay({
                         </div>
                     )}
 
-                    <div className={`${styles.localVideoPip} ${isVideoOff ? styles.localVideoPipHidden : ''}`}>
+                    <div className={`${styles.localVideoPip} ${isVideoOff ? styles.localVideoPipHidden : ''} ${isMinimized ? styles.localVideoPipHidden : ''}`}>
                         <video ref={localVideoRef} autoPlay playsInline muted />
                     </div>
 
-                    <div className={styles.videoControlBar}>
-                        {callState === 'ringing' ? (
-                            <>
-                                <button className={`${styles.glassBtn} ${styles.glassBtnDanger}`} onClick={onReject} aria-label="Decline">
-                                    <PhoneOff size={20} strokeWidth={2} />
-                                </button>
-                                <button className={`${styles.glassBtn} ${styles.glassBtnAccept}`} onClick={onAccept} aria-label="Accept">
-                                    <Video size={20} strokeWidth={2} />
-                                </button>
-                            </>
-                        ) : (
-                            <>
-                                <button
-                                    className={`${styles.glassBtn} ${isMuted ? styles.glassBtnActive : ''}`}
-                                    onClick={onToggleMute}
-                                    aria-label={isMuted ? 'Unmute' : 'Mute'}
-                                >
-                                    {isMuted ? <MicOff size={18} strokeWidth={2} /> : <Mic size={18} strokeWidth={2} />}
-                                </button>
-                                <button
-                                    className={`${styles.glassBtn} ${isVideoOff ? styles.glassBtnActive : ''}`}
-                                    onClick={onToggleVideo}
-                                    aria-label={isVideoOff ? 'Turn camera on' : 'Turn camera off'}
-                                >
-                                    {isVideoOff ? <VideoOff size={18} strokeWidth={2} /> : <Video size={18} strokeWidth={2} />}
-                                </button>
-                                <button className={`${styles.glassBtn} ${styles.glassBtnEnd}`} onClick={onEnd} aria-label="End call">
-                                    <PhoneOff size={18} strokeWidth={2} />
-                                </button>
-                            </>
-                        )}
-                    </div>
+                    {isMinimized ? (
+                        <button
+                            className={styles.miniEndBtn}
+                            style={{ position: 'absolute', bottom: 8, right: 8 }}
+                            onClick={(e) => { e.stopPropagation(); onEnd(); }}
+                            aria-label="End call"
+                        >
+                            <PhoneOff size={16} strokeWidth={2} />
+                        </button>
+                    ) : (
+                        <div className={styles.videoControlBar}>
+                            {callState === 'ringing' ? (
+                                <>
+                                    <button className={`${styles.glassBtn} ${styles.glassBtnDanger}`} onClick={onReject} aria-label="Decline">
+                                        <PhoneOff size={20} strokeWidth={2} />
+                                    </button>
+                                    <button className={`${styles.glassBtn} ${styles.glassBtnAccept}`} onClick={onAccept} aria-label="Accept">
+                                        <Video size={20} strokeWidth={2} />
+                                    </button>
+                                </>
+                            ) : (
+                                <>
+                                    <button
+                                        className={`${styles.glassBtn} ${isMuted ? styles.glassBtnActive : ''}`}
+                                        onClick={onToggleMute}
+                                        aria-label={isMuted ? 'Unmute' : 'Mute'}
+                                    >
+                                        {isMuted ? <MicOff size={18} strokeWidth={2} /> : <Mic size={18} strokeWidth={2} />}
+                                    </button>
+                                    <button
+                                        className={`${styles.glassBtn} ${isVideoOff ? styles.glassBtnActive : ''}`}
+                                        onClick={onToggleVideo}
+                                        aria-label={isVideoOff ? 'Turn camera on' : 'Turn camera off'}
+                                    >
+                                        {isVideoOff ? <VideoOff size={18} strokeWidth={2} /> : <Video size={18} strokeWidth={2} />}
+                                    </button>
+                                    <button className={`${styles.glassBtn} ${styles.glassBtnEnd}`} onClick={onEnd} aria-label="End call">
+                                        <PhoneOff size={18} strokeWidth={2} />
+                                    </button>
+                                </>
+                            )}
+                        </div>
+                    )}
                 </div>
             </div>
         );

--- a/frontend/src/Components/CallProvider/index.jsx
+++ b/frontend/src/Components/CallProvider/index.jsx
@@ -129,6 +129,29 @@ export function CallProvider({ children }) {
         return () => { document.body.style.overflow = ''; };
     }, [callState, isMinimized]);
 
+    // localVideoRef/remoteVideoRef only exist once CallOverlay's video markup
+    // is actually mounted — but callUser/answerCall assign .srcObject right
+    // after getUserMedia resolves, before that first render has happened (the
+    // caller's local preview was always blank because of this: at that exact
+    // moment callState was still 'idle', so the ref was null and the
+    // assignment silently no-opped). Re-syncing here on every render where
+    // the call is live catches the ref the moment it actually exists, and
+    // also re-attaches the streams if the video elements ever remount (e.g.
+    // were structured to unmount/remount around minimizing).
+    useEffect(() => {
+        if (callState === 'idle') return;
+        if (localVideoRef.current && localStream.current) {
+            localVideoRef.current.srcObject = localStream.current;
+        }
+        if (remoteVideoRef.current && peerConnection.current) {
+            const receivers = peerConnection.current.getReceivers?.() || [];
+            const tracks = receivers.map(r => r.track).filter(Boolean);
+            if (tracks.length && !remoteVideoRef.current.srcObject) {
+                remoteVideoRef.current.srcObject = new MediaStream(tracks);
+            }
+        }
+    });
+
     const createPeerConnection = useCallback((targetUserId) => {
         const pc = new RTCPeerConnection(ICE_SERVERS);
 

--- a/frontend/src/Components/ui/PageLoader.jsx
+++ b/frontend/src/Components/ui/PageLoader.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+/** Full-page loading state — swap in for `return null` during an auth/mount
+ * check so navigating/refreshing shows a spinner instead of a blank flash. */
+export default function PageLoader() {
+  return (
+    <div className="min-h-screen w-full flex items-center justify-center bg-[var(--mt-canvas)]">
+      <div
+        className="size-10 rounded-full border-[3px] border-t-transparent animate-spin"
+        style={{ borderColor: 'var(--mt-accent)', borderTopColor: 'transparent' }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/dashboard/index.jsx
+++ b/frontend/src/pages/dashboard/index.jsx
@@ -10,6 +10,7 @@ import {
   toggleBookmark,
 } from "@/config/redux/action/postAction";
 import DashboardLayout from "@/layout/DashboardLayout";
+import PageLoader from "@/Components/ui/PageLoader";
 import { useRouter } from "next/router";
 import React, { useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -311,7 +312,7 @@ export default function Dashboard() {
   }, [postState.postId]);
 
   // Prevent Hydration error
-  if (!isMounted) return null;
+  if (!isMounted) return <PageLoader />;
 
   // ... your return JSX remains exactly the same
 

--- a/frontend/src/pages/login/index.jsx
+++ b/frontend/src/pages/login/index.jsx
@@ -8,6 +8,7 @@ import { emptyMessage } from '@/config/redux/reducer/authReducer'
 import { getSavedAccounts } from '@/config/savedAccounts'
 import Button from '@/Components/ui/Button'
 import GoogleLoginButton from '@/Components/ui/GoogleLoginButton'
+import PageLoader from '@/Components/ui/PageLoader'
 
 const RESEND_COOLDOWN_S = 60;
 
@@ -175,7 +176,7 @@ function LoginComponent() {
     }
   };
 
-  if (isChecking) return null;
+  if (isChecking) return <PageLoader />;
 
   return (
     <UserLayout>

--- a/frontend/src/pages/my_network/index.jsx
+++ b/frontend/src/pages/my_network/index.jsx
@@ -8,6 +8,7 @@ import styles from './mynetwork.module.css'
 import { useRouter } from 'next/router';
 import { Phone, MessageCircle, Check, X, UsersRound, Inbox, SendHorizontal } from 'lucide-react';
 import EmptyState from '@/Components/ui/EmptyState';
+import PageLoader from '@/Components/ui/PageLoader';
 import { useCall } from '@/Components/CallProvider';
 
 export default function MyNetwork() {
@@ -87,7 +88,7 @@ export default function MyNetwork() {
         }
     };
 
-    if (!isMounted) return null;
+    if (!isMounted) return <PageLoader />;
 
     return (
                     <DashboardLayout>


### PR DESCRIPTION
## Summary
- Caller-side local video preview was blank due to a ref-timing race (localVideoRef didn't exist yet when the stream was assigned).
- Minimizing a video call unmounted the <video> elements, permanently losing the stream on expand. Minimize is now a pure CSS shrink.
- Added a real PageLoader spinner in place of blank `return null` flashes on dashboard/my_network/login initial mount.

## Test plan
- [ ] Laptop calls mobile (video): confirm laptop shows both local + remote video
- [ ] Minimize a video call, wait, expand: confirm video is still live, not blank
- [ ] Refresh dashboard/my_network/login: confirm a spinner shows instead of a blank flash