### PR TITLE
fix: OTP mail delivery ENETUNREACH + resilient register/resend

### DIFF
--- a/backend/config/mailer.js
+++ b/backend/config/mailer.js
@@ -10,6 +10,11 @@ const transporter = process.env.EMAIL_APP_PASSWORD
             user: process.env.EMAIL_USER,
             pass: process.env.EMAIL_APP_PASSWORD,
         },
+        // Render's containers have no IPv6 egress route, but Node's default
+        // DNS resolution for smtp.gmail.com can still hand back an AAAA
+        // record first — every send then failed with ENETUNREACH before it
+        // ever reached Gmail. Forcing IPv4 is what actually fixes it.
+        family: 4,
     })
     : null;
 

--- a/backend/controllers/otp.controller.js
+++ b/backend/controllers/otp.controller.js
@@ -37,11 +37,20 @@ const issueOtp = async (email, purpose) => {
     await Otp.deleteMany({ email, purpose });
     const otp = generateOtp();
     await Otp.create({ email, purpose, otpHash: hashOtp(otp) });
-    await sendMail({
-        to: email,
-        subject: purpose === "signup" ? "Verify your Mitrata account" : "Reset your Mitrata password",
-        html: otpEmailHtml(otp, purpose),
-    });
+    try {
+        await sendMail({
+            to: email,
+            subject: purpose === "signup" ? "Verify your Mitrata account" : "Reset your Mitrata password",
+            html: otpEmailHtml(otp, purpose),
+        });
+    } catch (mailError) {
+        // The OTP row above is already saved with a real code — a transport
+        // hiccup here (as opposed to the rate-limit check above, which is
+        // deliberate and still throws) shouldn't turn into a 500 that makes
+        // register/resend look like they failed outright. resendOtp is the
+        // user's recovery path if this particular send didn't land.
+        console.error(`sendMail failed for ${email} (${purpose}):`, mailError.message);
+    }
 };
 
 export const sendOtp = async (req, res) => {


### PR DESCRIPTION
Registering a real account just failed live with connect ENETUNREACH — Render has no IPv6 egress but Gmail's SMTP hostname can still resolve to an AAAA record first. Forced IPv4 (family: 4) on the nodemailer transport, and made a mail-send failure non-fatal to register/resendOtp since the OTP row is already persisted by that point.