### PR TITLE
fix: resolve Gmail SMTP IPv4 address directly (transport options weren't honored)

### DIFF
--- a/backend/config/mailer.js
+++ b/backend/config/mailer.js
@@ -1,32 +1,43 @@
 import nodemailer from "nodemailer";
-import dns from "dns";
+import dns from "dns/promises";
 
 // Gmail SMTP requires a 16-character App Password (Google Account > Security
 // > 2-Step Verification > App Passwords), not the account's normal login
 // password — Gmail rejects plain-password SMTP login outright.
-const transporter = process.env.EMAIL_APP_PASSWORD
-    ? nodemailer.createTransport({
-        service: "gmail",
-        auth: {
-            user: process.env.EMAIL_USER,
-            pass: process.env.EMAIL_APP_PASSWORD,
-        },
-        // Render's containers have no IPv6 egress route, but Node's default
-        // DNS resolution for smtp.gmail.com can still hand back an AAAA
-        // record first — every send then failed with ENETUNREACH before it
-        // ever reached Gmail. `family: 4` alone did NOT fix this in practice
-        // (confirmed live — kept failing with the same error after adding
-        // it): nodemailer's "service" shorthand doesn't reliably thread that
-        // option down to the actual socket connect call. A custom `lookup`
-        // forces the DNS resolution itself to IPv4, which is what actually
-        // controls which address gets dialed.
-        family: 4,
-        lookup: (hostname, options, callback) => dns.lookup(hostname, { family: 4 }, callback),
-    })
-    : null;
+const emailConfigured = !!process.env.EMAIL_APP_PASSWORD;
+
+// Render's containers have no IPv6 egress route, but DNS resolution for
+// smtp.gmail.com can still hand back an AAAA record, and every send then
+// fails with ENETUNREACH before ever reaching Gmail. Neither `family: 4` nor
+// a custom `lookup` on the transport options fixed this in practice —
+// confirmed live, both still failed with the same error — because
+// nodemailer's "service": "gmail" shorthand doesn't reliably thread either
+// option down to the actual socket connect call. Resolving the IPv4 address
+// ourselves and connecting directly to it is the only thing that reliably
+// worked; `tls.servername` keeps certificate validation correct despite
+// connecting via a bare IP instead of the hostname.
+let transporterPromise = null;
+const getTransporter = async () => {
+    if (!emailConfigured) return null;
+    if (!transporterPromise) {
+        transporterPromise = dns.lookup("smtp.gmail.com", { family: 4 }).then(({ address }) =>
+            nodemailer.createTransport({
+                host: address,
+                port: 465,
+                secure: true,
+                tls: { servername: "smtp.gmail.com" },
+                auth: {
+                    user: process.env.EMAIL_USER,
+                    pass: process.env.EMAIL_APP_PASSWORD,
+                },
+            })
+        );
+    }
+    return transporterPromise;
+};
 
 export const sendMail = async ({ to, subject, html }) => {
-    if (!transporter) {
+    if (!emailConfigured) {
         // Same "disabled until configured" pattern as googleLogin — lets the
         // rest of the app run locally before the App Password is set up.
         // Logging the body here (not just the subject) is what makes OTP
@@ -35,6 +46,7 @@ export const sendMail = async ({ to, subject, html }) => {
         console.warn(`EMAIL_APP_PASSWORD not set — skipping email to ${to}: ${subject}\n${html}`);
         return;
     }
+    const transporter = await getTransporter();
     await transporter.sendMail({
         from: `"Mitrata" <${process.env.EMAIL_USER}>`,
         to,


### PR DESCRIPTION
Both family:4 and a custom lookup option still failed with ENETUNREACH live — nodemailer's service:'gmail' shorthand doesn't reliably thread either through to the actual connect call. Resolving smtp.gmail.com ourselves and connecting to that IP directly (with tls.servername for correct cert validation) sidesteps the option-plumbing question entirely.