### PR TITLE
chore: add .vercelignore to stop uploading mobile/backend/node_modules

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,7 @@
+# Deploying from the repo root (monorepo) — only frontend/ is actually
+# needed; everything else here was getting uploaded too (891MB, including
+# the 1.3GB Flutter mobile/ project, which broke the deploy outright).
+mobile/
+backend/
+node_modules/
+.git/


### PR DESCRIPTION
Deploying from repo root without an ignore file uploaded 891MB (including the 1.3GB Flutter mobile/ project) and failed on Vercel's 100MB file-size limit.