### PR TITLE
fix: deeper audit — auth/security bugs, messaging bugs, real per-user posts

### DIFF
--- a/backend/config/cloudinary.js
+++ b/backend/config/cloudinary.js
@@ -14,10 +14,15 @@ cloudinary.config({
 // Setup Cloudinary Storage for Multer
 export const Storage = new CloudinaryStorage({
   cloudinary: cloudinary,
-  
+
   params: {
     upload_preset: 'mitrata_social',
     folder: 'mitrata_social', // Name of the folder in Cloudinary
-    allowed_formats: ['jpg', 'png', 'jpeg'],
+    // resource_type: 'auto' lets Cloudinary route video vs image correctly —
+    // without it every upload was forced through the image pipeline, so any
+    // video (messaging attachments, video stories — both wired up in the UI
+    // with accept="image/*,video/*") failed outright regardless of format.
+    resource_type: 'auto',
+    allowed_formats: ['jpg', 'jpeg', 'png', 'gif', 'webp', 'mp4', 'mov', 'webm'],
   },
 });

--- a/backend/controllers/admin.controller.js
+++ b/backend/controllers/admin.controller.js
@@ -1,3 +1,4 @@
+import mongoose from "mongoose";
 import User from "../models/users.model.js";
 import Post from "../models/posts.model.js";
 import Comment from "../models/comments.model.js";
@@ -87,6 +88,16 @@ export const createReport = async (req, res) => {
         const { targetType, targetId, reason } = req.body;
         if (!targetType || !targetId || !reason) {
             return res.status(400).json({ message: "targetType, targetId and reason are required" });
+        }
+        if (!mongoose.Types.ObjectId.isValid(targetId)) {
+            return res.status(400).json({ message: "targetId is not a valid id" });
+        }
+        // Without this, re-clicking "Report" (or a scripted retry) queued a
+        // fresh duplicate every time — the moderation queue was one bad
+        // click away from filling up with copies of the same report.
+        const existing = await Report.findOne({ reporterId: req.userId, targetType, targetId, status: "pending" });
+        if (existing) {
+            return res.status(409).json({ message: "You've already reported this" });
         }
         const report = await Report.create({ reporterId: req.userId, targetType, targetId, reason });
         return res.json({ message: "Report submitted", report });

--- a/backend/controllers/message.controller.js
+++ b/backend/controllers/message.controller.js
@@ -1,6 +1,7 @@
 import mongoose from "mongoose";
 import Message from "../models/message.model.js";
 import Notification from "../models/notification.model.js";
+import ConnectionRequest from "../models/connection.model.js";
 import { v2 as cloudinary } from "cloudinary";
 
 export const sendMessage = async (req, res) => {
@@ -16,8 +17,23 @@ export const sendMessage = async (req, res) => {
         });
 
         // Validate receiver exists
-        if (!receiverId) {
-            return res.status(400).json({ message: "Receiver ID is required" });
+        if (!receiverId || !mongoose.Types.ObjectId.isValid(receiverId)) {
+            return res.status(400).json({ message: "A valid receiver ID is required" });
+        }
+
+        // The messaging UI only ever exposes a Send button on your own
+        // connections list — nothing server-side enforced that, so any
+        // authenticated account could DM (and get a notification bell entry
+        // in front of) a complete stranger via a direct API call.
+        const isConnected = await ConnectionRequest.exists({
+            status_accepted: true,
+            $or: [
+                { userId: senderId, connectionId: receiverId },
+                { userId: receiverId, connectionId: senderId }
+            ]
+        });
+        if (!isConnected) {
+            return res.status(403).json({ message: "You can only message accepted connections" });
         }
 
         // Handle Multiple Files (Up to 5)
@@ -240,20 +256,16 @@ export const deleteMessages = async (req, res) => {
 
         console.log("Messages marked as deleted:", result.modifiedCount);
 
-        // SOCKET.IO REAL-TIME EMISSION (optional - to notify other user)
+        // "Delete for me" only hides these messages for the caller (that's
+        // all the $addToSet above did) — it emitted to the OTHER
+        // participant's room, so their live chat silently lost messages
+        // that, for them, were never actually deleted (they'd reappear on
+        // their next reload). This is meant to sync the caller's OWN other
+        // open tabs/devices, so it needs to target the caller's room, not
+        // the other person's.
         const io = req.app.get("socketio");
-
         if (io) {
-            // Get the messages to find the other user
-            const messages = await Message.find({ _id: { $in: messageIds } });
-
-            messages.forEach(msg => {
-                const otherUserId = msg.sender.toString() === senderId.toString()
-                    ? msg.receiver.toString()
-                    : msg.sender.toString();
-
-                io.to(otherUserId).emit("messagesDeleted", { messageIds, deletedBy: senderId });
-            });
+            io.to(senderId.toString()).emit("messagesDeleted", { messageIds, deletedBy: senderId });
         }
 
         res.status(200).json({

--- a/backend/controllers/post.controller.js
+++ b/backend/controllers/post.controller.js
@@ -204,6 +204,52 @@ export const getAllPosts = async (req, res) => {
   }
 };
 
+// profile/activity/view_profile were all filtering *one page* of the
+// engagement-ranked global getAllPosts() feed down to a single username —
+// a user's own posts that didn't rank into that page (very likely once
+// they have more than a handful) were invisible on their own profile.
+// This queries their actual posts directly instead.
+export const getPostsByUsername = async (req, res) => {
+  try {
+    const requesterId = req.userId;
+    const { username } = req.params;
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 20;
+    const skip = (page - 1) * limit;
+
+    const author = await User.findOne({ username }).select("_id").lean();
+    if (!author) {
+      return res.status(404).json({ message: "User not found" });
+    }
+
+    const query = { userId: author._id };
+    const [posts, totalPosts] = await Promise.all([
+      Post.find(query)
+        .sort({ createId: -1 })
+        .skip(skip)
+        .limit(limit)
+        .populate("userId", "name username email profilePicture createdAt")
+        .lean(),
+      Post.countDocuments(query)
+    ]);
+
+    const formattedPosts = posts.map((post) => ({
+      ...post,
+      ...summarise(post.reactions, requesterId),
+    }));
+
+    return res.status(200).json({
+      posts: formattedPosts,
+      hasMore: skip + limit < totalPosts,
+      totalPosts,
+      page,
+      limit
+    });
+  } catch (error) {
+    return res.status(500).json({ message: error.message });
+  }
+};
+
 export const deletePost = async (req, res) => {
   const { post_id } = req.body;
   try {

--- a/backend/controllers/story.controller.js
+++ b/backend/controllers/story.controller.js
@@ -47,6 +47,10 @@ export const getStories = async (req, res) => {
 
         const grouped = new Map();
         for (const story of stories) {
+            // populate() leaves this null if the author user doc is ever
+            // missing — .toString() on that would throw and take the whole
+            // feed down with it, for every story in the batch, not just theirs.
+            if (!story.userId) continue;
             const key = story.userId._id.toString();
             if (!grouped.has(key)) {
                 grouped.set(key, { user: story.userId, stories: [], allViewed: true });

--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -741,10 +741,17 @@ export const searchUsers = async (req, res) => {
             },
             {
                 $match: {
+                    // Suspended accounts shouldn't be discoverable via public
+                    // search regardless of what matches.
+                    active: true,
                     $or: [
                         { name: regex },
                         { username: regex },
-                        { email: regex },
+                        // No email match: this route has no auth, so matching
+                        // on email turned it into an account-enumeration
+                        // oracle — feed in someone's email and a hit confirms
+                        // they're registered and hands back their name,
+                        // username, avatar, bio and work history.
                         { 'profile.bio': regex },
                         { 'profile.skills': regex },
                         { 'profile.education.school': regex },

--- a/backend/routes/post.routes.js
+++ b/backend/routes/post.routes.js
@@ -1,12 +1,12 @@
 
 import { Router } from "express";
-import { activecheck, commentPost, createPost, delete_Comments, deletePost, getAllPosts, getBookmarkedPosts, getComment_by_Post, getLikedPosts, getPostAnalytics, getPostById, getPublicStats, getTrendingTags, reactToComplaint, toggleBookmark } from "../controllers/post.controller.js";
+import { activecheck, commentPost, createPost, delete_Comments, deletePost, getAllPosts, getBookmarkedPosts, getComment_by_Post, getLikedPosts, getPostAnalytics, getPostById, getPostsByUsername, getPublicStats, getTrendingTags, reactToComplaint, toggleBookmark } from "../controllers/post.controller.js";
 import { verifyToken } from "../middleware/auth.middleware.js";
 import multer from "multer";
 import { Storage } from "../config/cloudinary.js";
 const router = Router();
 
-const upload = multer({ storage: Storage })
+const upload = multer({ storage: Storage, limits: { fileSize: 25 * 1024 * 1024 } })
 
 // Public health check
 router.route("/").get(activecheck);
@@ -19,8 +19,9 @@ router.route('/trending/tags').get(getTrendingTags);
 router.route('/stats/public').get(getPublicStats);
 
 // All post routes require authentication
-router.route('/post').post(upload.single('media'), verifyToken, createPost);
+router.route('/post').post(verifyToken, upload.single('media'), createPost);
 router.route('/posts').get(verifyToken, getAllPosts);
+router.route('/posts/user/:username').get(verifyToken, getPostsByUsername);
 router.route('/delete_post').post(verifyToken, deletePost);
 router.route('/comment_post').post(verifyToken, commentPost);
 router.route('/getcomment_by_post').get(verifyToken, getComment_by_Post);

--- a/backend/routes/story.routes.js
+++ b/backend/routes/story.routes.js
@@ -5,9 +5,9 @@ import { Storage } from "../config/cloudinary.js";
 import { createStory, deleteStory, getStories, viewStory } from "../controllers/story.controller.js";
 
 const router = Router();
-const upload = multer({ storage: Storage });
+const upload = multer({ storage: Storage, limits: { fileSize: 25 * 1024 * 1024 } });
 
-router.route("/story").post(upload.single("media"), verifyToken, createStory);
+router.route("/story").post(verifyToken, upload.single("media"), createStory);
 router.route("/stories").get(verifyToken, getStories);
 router.route("/story/:id/view").post(verifyToken, viewStory);
 router.route("/story/:id").delete(verifyToken, deleteStory);

--- a/backend/routes/user.routes.js
+++ b/backend/routes/user.routes.js
@@ -9,7 +9,7 @@ import { Storage } from "../config/cloudinary.js";
 import { deleteChat, deleteMessageForEveryone, deleteMessages, getConversations, getMessages, markMessagesRead, sendMessage } from "../controllers/message.controller.js";
 const router = Router();
 
-const upload = multer({ storage: Storage })
+const upload = multer({ storage: Storage, limits: { fileSize: 25 * 1024 * 1024 } })
 
 // ============ PUBLIC ROUTES (no auth needed) ============
 router.route("/register").post(register);
@@ -30,9 +30,13 @@ router.route('/report').post(verifyToken, createReport);
 // ============ PROTECTED ROUTES (auth required) ============
 
 // Profile routes
-router.route('/user/update_profile_picture').post(upload.single('profilePicture'), verifyToken, uploadProfilePicture);
-router.route('/user/update_cover_photo').post(upload.single('coverPhoto'), verifyToken, uploadCoverPhoto);
-router.route('/upload/image').post(upload.single('image'), verifyToken, uploadImage);
+// verifyToken runs BEFORE multer — multer's CloudinaryStorage uploads to
+// Cloudinary as it parses the body, so with auth checked after, an
+// unauthenticated request already had its file stored (and billed) before
+// ever hitting the 401. Auth has to gate the upload, not follow it.
+router.route('/user/update_profile_picture').post(verifyToken, upload.single('profilePicture'), uploadProfilePicture);
+router.route('/user/update_cover_photo').post(verifyToken, upload.single('coverPhoto'), uploadCoverPhoto);
+router.route('/upload/image').post(verifyToken, upload.single('image'), uploadImage);
 router.route('/user/setting/user_update').post(verifyToken, updateUserProfile);
 router.route('/get_user_and_profile').get(verifyToken, getUserAndProfile);
 router.route('/update_profile').post(verifyToken, updateProfileData);
@@ -54,9 +58,9 @@ router.route('/user/get_user_based_on_username').get(getAllUserBasedOnUsername);
 
 // Messaging routes (all protected)
 router.route('/user/send_message').post(
-    upload.array('media', 5),   // Multer parses form data FIRST
-    verifyToken,                // THEN verify token
-    sendMessage                 // THEN send message
+    verifyToken,                // Auth gates the upload, not the other way around
+    upload.array('media', 5),
+    sendMessage
 );
 
 router.route('/user/get_messages').get(

--- a/frontend/src/config/redux/action/postAction/index.js
+++ b/frontend/src/config/redux/action/postAction/index.js
@@ -97,6 +97,22 @@ export const getLikedPosts = createAsyncThunk(
     }
 )
 
+// profile/activity/view_profile used to filter one page of getAllPosts()
+// (an engagement-ranked global feed) down to a single username — a user's
+// own posts that didn't happen to rank into that page were invisible on
+// their own profile. This queries their real posts directly.
+export const getPostsByUsername = createAsyncThunk(
+    'post/getPostsByUsername',
+    async ({ username, page = 1 } = {}, thunkapi) => {
+        try {
+            const response = await clientServer.get(`/posts/user/${username}`, { params: { page } });
+            return thunkapi.fulfillWithValue(response.data);
+        } catch (error) {
+            return thunkapi.rejectWithValue(error.response?.data || { message: "Failed to load posts" })
+        }
+    }
+)
+
 export const toggleBookmark = createAsyncThunk(
     'post/toggleBookmark',
     async (postId, thunkapi) => {

--- a/frontend/src/config/redux/reducer/messageReducer/index.js
+++ b/frontend/src/config/redux/reducer/messageReducer/index.js
@@ -39,6 +39,26 @@ const messageSlice = createSlice({
             state.messages.forEach((msg) => {
                 msg.isRead = true;
             });
+        },
+
+        /* A "newMessage" socket event only ever pushed into the currently
+           open thread — the sidebar's conversation list (preview text,
+           unread badge, recency sort) never updated for it, so a message
+           from anyone you weren't actively chatting with sat there stale
+           until a full reload. */
+        bumpConversation: (state, action) => {
+            const { senderId, lastMessage, isActiveChat } = action.payload;
+            const convo = state.conversations.find((c) => c.userId === senderId);
+            if (convo) {
+                convo.lastMessage = lastMessage;
+                if (!isActiveChat) convo.unreadCount = (convo.unreadCount || 0) + 1;
+            } else {
+                state.conversations.push({
+                    userId: senderId,
+                    lastMessage,
+                    unreadCount: isActiveChat ? 0 : 1
+                });
+            }
         }
     },
 
@@ -154,5 +174,5 @@ const messageSlice = createSlice({
     }
 });
 
-export const { pushMessage, resetMessages, removeDeletedMessages, markMyMessagesRead } = messageSlice.actions;
+export const { pushMessage, resetMessages, removeDeletedMessages, markMyMessagesRead, bumpConversation } = messageSlice.actions;
 export default messageSlice.reducer;

--- a/frontend/src/config/redux/reducer/postReducer/index.js
+++ b/frontend/src/config/redux/reducer/postReducer/index.js
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { commentPost, createPost, getAllComments, getAllPosts, getBookmarkedPosts, getLikedPosts, reactToPost, toggleBookmark } from '../../action/postAction';
+import { commentPost, createPost, getAllComments, getAllPosts, getBookmarkedPosts, getLikedPosts, getPostsByUsername, reactToPost, toggleBookmark } from '../../action/postAction';
 
 
 
@@ -7,6 +7,9 @@ const initialState = {
     posts: [],
     likedPosts: [],
     bookmarkedPosts: [],
+    userPosts: [],
+    userPostsHasMore: false,
+    userPostsPage: 1,
     isError: false,
     postFetched: false,
     isLoading: false,
@@ -99,13 +102,17 @@ const postSlice = createSlice({
             .addCase(reactToPost.fulfilled, (state, action) => {
                 // Patch the single post in place — no full refetch needed,
                 // this is the same data getAllPosts already returns per-post.
+                // Also patches userPosts (activity/profile/view_profile's own
+                // posts list) — same post, same shape, just a different array.
                 const { postId, counts, likeCount, dislikeCount, reactions } = action.payload;
-                const post = state.posts.find((p) => p._id === postId);
-                if (post) {
-                    post.counts = counts;
-                    post.likeCount = likeCount;
-                    post.dislikeCount = dislikeCount;
-                    post.reactions = reactions;
+                for (const list of [state.posts, state.userPosts]) {
+                    const post = list.find((p) => p._id === postId);
+                    if (post) {
+                        post.counts = counts;
+                        post.likeCount = likeCount;
+                        post.dislikeCount = dislikeCount;
+                        post.reactions = reactions;
+                    }
                 }
             })
             .addCase(getLikedPosts.fulfilled, (state, action) => {
@@ -113,11 +120,19 @@ const postSlice = createSlice({
             })
             .addCase(toggleBookmark.fulfilled, (state, action) => {
                 const { postId, bookmarked } = action.payload;
-                const post = state.posts.find((p) => p._id === postId);
-                if (post) post.bookmarked = bookmarked;
+                for (const list of [state.posts, state.userPosts]) {
+                    const post = list.find((p) => p._id === postId);
+                    if (post) post.bookmarked = bookmarked;
+                }
             })
             .addCase(getBookmarkedPosts.fulfilled, (state, action) => {
                 state.bookmarkedPosts = action.payload.posts || []
+            })
+            .addCase(getPostsByUsername.fulfilled, (state, action) => {
+                const { posts, hasMore, page } = action.payload;
+                state.userPosts = page > 1 ? [...state.userPosts, ...(posts || [])] : (posts || []);
+                state.userPostsHasMore = !!hasMore;
+                state.userPostsPage = page || 1;
             })
     }
 })

--- a/frontend/src/pages/activity/[username].jsx
+++ b/frontend/src/pages/activity/[username].jsx
@@ -5,7 +5,7 @@ import styles from './index.module.css';
 import DashboardLayout from '@/layout/DashboardLayout';
 import ReportMenu from '@/Components/ReportMenu';
 import EmptyState from '@/Components/ui/EmptyState';
-import { getAllPosts, deletePost, reactToPost, getAllComments, commentPost, toggleBookmark } from '@/config/redux/action/postAction';
+import { getPostsByUsername, deletePost, reactToPost, getAllComments, commentPost, toggleBookmark } from '@/config/redux/action/postAction';
 import { resetPostId } from '@/config/redux/reducer/postReducer';
 import { Base_Url } from '@/config';
 import { useToast } from '@/Components/Toast';
@@ -39,7 +39,7 @@ export default function UserActivityPage() {
     const toast = useToast();
 
     const refreshData = () => {
-        dispatch(getAllPosts());
+        if (username) dispatch(getPostsByUsername({ username }));
     };
 
     useEffect(() => {
@@ -53,19 +53,21 @@ export default function UserActivityPage() {
 
     useEffect(() => {
         setMounted(true);
-        const token = localStorage.getItem('token');
-        // Only fetch if Redux is empty to prevent "loading every time" flicker
-        if (token && postState.posts.length === 0) {
-            dispatch(getAllPosts());
-        }
-    }, [dispatch]);
+    }, []);
 
-    const userPosts = useMemo(() => {
-        if (postState.posts && username) {
-            return postState.posts.filter(post => post.userId?.username === username);
+    // Was reusing whatever was already in Redux for `posts` (the global
+    // feed) whenever it was non-empty — which could just as easily be a
+    // `feed=following` list from the dashboard, one that by definition
+    // never contains your own posts. Fetches this user's real posts
+    // directly instead, whenever `username` is actually available.
+    useEffect(() => {
+        const token = localStorage.getItem('token');
+        if (token && username) {
+            dispatch(getPostsByUsername({ username }));
         }
-        return [];
-    }, [postState.posts, username]);
+    }, [dispatch, username]);
+
+    const userPosts = postState.userPosts || [];
 
     const isOwner = authState.user?.userId?.username === username;
 
@@ -106,7 +108,7 @@ export default function UserActivityPage() {
     const handleDelete = (postId) => {
         if (window.confirm("Are you sure you want to delete this post?")) {
             dispatch(deletePost(postId)).then(() => {
-                dispatch(getAllPosts());
+                refreshData();
                 toast.success("Post deleted.");
             });
         }

--- a/frontend/src/pages/messaging/[username].jsx
+++ b/frontend/src/pages/messaging/[username].jsx
@@ -4,7 +4,7 @@ import DashboardLayout from '@/layout/DashboardLayout';
 import { useRouter } from 'next/router';
 import { useSelector, useDispatch } from 'react-redux';
 import { Base_Url } from '@/config';
-import { pushMessage, resetMessages, removeDeletedMessages, markMyMessagesRead } from '@/config/redux/reducer/messageReducer';
+import { pushMessage, resetMessages, removeDeletedMessages, markMyMessagesRead, bumpConversation } from '@/config/redux/reducer/messageReducer';
 import { getMessages, sendMessage, deleteMessages, deleteChat, deleteMessageForEveryone, getConversations, markMessagesRead } from '@/config/redux/action/messageAction';
 import { getAboutUser, getMyConnectionRequests } from '@/config/redux/action/authAction';
 import { useToast } from '@/Components/Toast';
@@ -34,7 +34,6 @@ export default function Messaging() {
     const [previewMedia, setPreviewMedia] = useState(null);
     const [selectionMode, setSelectionMode] = useState(false);
     const [selectedMessages, setSelectedMessages] = useState([]);
-    const [deleting, setDeleting] = useState(false);
     const [showDeleteMenu, setShowDeleteMenu] = useState(false);
     const [isTyping, setIsTyping] = useState(false);
     const deleteMenuRef = useRef(null);
@@ -137,16 +136,24 @@ export default function Messaging() {
 
         const handleNewMessage = (data) => {
             const senderId = data.sender?.userId?._id || data.sender?._id || data.sender;
-            if (senderId === activeChatUser?.userId?._id) {
+            const isActiveChat = senderId === activeChatUser?.userId?._id;
+            if (isActiveChat) {
                 dispatch(pushMessage(data));
             }
+            // Previously only the active thread's messages array updated —
+            // the sidebar's preview/unread badge for this sender never did,
+            // so a message from anyone else stayed stale until reload.
+            dispatch(bumpConversation({ senderId, lastMessage: data, isActiveChat }));
         };
 
+        // Backend now emits this only to the deleter's own room (see
+        // deleteMessages) — it's for syncing this same account's OTHER open
+        // tabs, not the other participant. The tab that triggered the
+        // delete already removed these via deleteMessages.fulfilled, so
+        // reprocessing here is a harmless no-op there and the real effect
+        // for any other tab of this account.
         const handleMessagesDeleted = (data) => {
-            const { messageIds, deletedBy } = data;
-            if (deletedBy !== myId) {
-                dispatch(removeDeletedMessages({ messageIds }));
-            }
+            dispatch(removeDeletedMessages({ messageIds: data.messageIds }));
         };
 
         const handleMessageDeletedForEveryone = (data) => {
@@ -193,10 +200,17 @@ export default function Messaging() {
     }, [activeChatUser, dispatch]);
 
     // The other person read our messages while this thread is open — flip
-    // our sent bubbles to the read state and refresh their unread badge.
+    // our sent bubbles to the read state. This ignored WHO the read receipt
+    // was actually from and marked the entire open thread read regardless —
+    // opening a chat with C would flip A's tick marks in a completely
+    // different, already-open thread with B.
     useEffect(() => {
         if (!socket.current) return;
-        const handleRead = () => dispatch(markMyMessagesRead());
+        const handleRead = ({ readBy }) => {
+            if (readBy === activeChatUser?.userId?._id) {
+                dispatch(markMyMessagesRead());
+            }
+        };
         socket.current.on("messagesRead", handleRead);
         return () => socket.current?.off("messagesRead", handleRead);
     }, [socket, activeChatUser, dispatch]);
@@ -327,10 +341,18 @@ export default function Messaging() {
     };
 
     /* -------------------- MESSAGE SELECTION -------------------- */
+    // The 600ms timer fires while the finger/mouse is still down, entering
+    // selection mode — releasing then fires the ordinary `click` on the same
+    // element, which immediately toggled that same message back off (every
+    // long-press looked like it selected and instantly deselected). This
+    // flag swallows exactly that one synthetic click.
+    const justLongPressedRef = useRef(false);
+
     const handleLongPressStart = (id) => {
         longPressTimer.current = setTimeout(() => {
             setSelectionMode(true);
             setSelectedMessages([id]);
+            justLongPressedRef.current = true;
         }, 600);
     };
 
@@ -339,6 +361,10 @@ export default function Messaging() {
     };
 
     const handleMessageClick = (id) => {
+        if (justLongPressedRef.current) {
+            justLongPressedRef.current = false;
+            return;
+        }
         if (selectionMode) {
             setSelectedMessages(prev =>
                 prev.includes(id) ? prev.filter(mId => mId !== id) : [...prev, id]
@@ -352,47 +378,20 @@ export default function Messaging() {
     };
 
 
-    const handleDeleteSelected = async () => {
-        if (selectedMessages.length === 0) return;
-
-        const confirmMsg = `Delete ${selectedMessages.length} message(s)? This will remove them from your view.`;
-        if (!window.confirm(confirmMsg)) return;
-
-        setDeleting(true);
-
+    // Both selected-messages actions ("Delete for me" / "Delete for
+    // everyone") are wired directly in the dropdown menu JSX below — these
+    // wrap them with error handling so a rejected delete (e.g. the 1-hour
+    // rule tripping mid-batch) surfaces a toast instead of an uncaught
+    // promise rejection that leaves the menu stuck open.
+    const runDelete = async (thunkPromise) => {
         try {
-            await dispatch(deleteMessages({ messageIds: selectedMessages })).unwrap();
-
-            setSelectionMode(false);
-            setSelectedMessages([]);
-            toast.success("Messages deleted successfully");
+            await thunkPromise;
+            setShowDeleteMenu(false);
+            handleCancelSelection();
         } catch (error) {
-            console.error("Error deleting messages:", error);
-            toast.error("Failed to delete messages. Please try again.");
-        } finally {
-            setDeleting(false);
+            toast.error(error?.message || "Failed to delete message(s)");
+            setShowDeleteMenu(false);
         }
-    };
-    const handleDeleteClick = async () => {
-        if (selectedMessages.length === 0) return;
-
-        // Check if only one message is selected to enable "Delete for Everyone"
-        const canDeleteForEveryone = selectedMessages.length === 1;
-
-        let choice;
-        if (canDeleteForEveryone) {
-            const result = window.confirm("Delete for Everyone? (Cancel for 'Delete for Me')");
-            if (result) {
-                await dispatch(deleteMessageForEveryone({ messageId: selectedMessages[0] })).unwrap();
-            } else {
-                await dispatch(deleteMessages({ messageIds: selectedMessages })).unwrap();
-            }
-        } else {
-            if (window.confirm(`Delete ${selectedMessages.length} messages for me?`)) {
-                await dispatch(deleteMessages({ messageIds: selectedMessages })).unwrap();
-            }
-        }
-        handleCancelSelection();
     };
 
     /* -------------------- SEARCH IN CHAT -------------------- */
@@ -405,9 +404,17 @@ export default function Messaging() {
     }, [messages, searchQuery]);
 
     /* -------------------- CREATE PREVIEW URL -------------------- */
-    const createPreviewUrl = (file) => {
-        return URL.createObjectURL(file);
-    };
+    // Was calling URL.createObjectURL(f) directly in the JSX map below —
+    // that ran on every render (every keystroke while composing a message),
+    // creating a fresh blob URL each time with nothing ever revoking the
+    // old ones. Computing these once per selectedFiles change (and
+    // revoking on the next change/unmount) is what actually releases them.
+    const [previewUrls, setPreviewUrls] = useState([]);
+    useEffect(() => {
+        const urls = selectedFiles.map((f) => URL.createObjectURL(f));
+        setPreviewUrls(urls);
+        return () => urls.forEach((u) => URL.revokeObjectURL(u));
+    }, [selectedFiles]);
 
     /* -------------------- HANDLE BACK BUTTON (MOBILE) -------------------- */
     const handleBackClick = () => {
@@ -436,12 +443,18 @@ export default function Messaging() {
     const canDeleteEveryone = useMemo(() => {
         if (selectedMessages.length === 0) return false;
 
-        // Check if EVERY selected message was sent by ME
+        // Check if EVERY selected message was sent by ME, and is still
+        // within the server's 1-hour window (matches the WhatsApp-style
+        // rule enforced in deleteMessageForEveryone) — this only checked
+        // authorship before, so picking an old message here would 403 on
+        // the server mid-batch with nothing but an uncaught rejection.
+        const oneHourAgo = Date.now() - 60 * 60 * 1000;
         return selectedMessages.every(id => {
             const msg = messages.find(m => m._id === id);
             if (!msg) return false;
             const senderId = msg.sender?.userId?._id || msg.sender?._id || msg.sender;
-            return senderId === authState.user?.userId?._id;
+            if (senderId !== authState.user?.userId?._id) return false;
+            return new Date(msg.createdAt).getTime() >= oneHourAgo;
         });
     }, [selectedMessages, messages, authState.user]);
 
@@ -537,27 +550,22 @@ export default function Messaging() {
                                                 <div className={`${styles.dropdownMenu} mt-dropdown-enter`}>
                                                     <button
                                                         className={styles.menuItem}
-                                                        onClick={async () => {
-                                                            await dispatch(deleteMessages({ messageIds: selectedMessages })).unwrap();
-                                                            setShowDeleteMenu(false);
-                                                            handleCancelSelection();
-                                                        }}
+                                                        onClick={() => runDelete(
+                                                            dispatch(deleteMessages({ messageIds: selectedMessages })).unwrap()
+                                                        )}
                                                     >
                                                         Delete for me
                                                     </button>
 
-                                                    {/* SMART CONDITION: Only show if all selected messages are mine */}
+                                                    {/* SMART CONDITION: Only show if all selected messages are mine and still within the 1-hour window */}
                                                     {canDeleteEveryone && (
                                                         <button
                                                             className={`${styles.menuItem} ${styles.danger}`}
-                                                            onClick={async () => {
-                                                                // Loop through all selected messages and delete each for everyone
+                                                            onClick={() => runDelete((async () => {
                                                                 for (const id of selectedMessages) {
                                                                     await dispatch(deleteMessageForEveryone({ messageId: id })).unwrap();
                                                                 }
-                                                                setShowDeleteMenu(false);
-                                                                handleCancelSelection();
-                                                            }}
+                                                            })())}
                                                         >
                                                             Delete for everyone
                                                         </button>
@@ -758,9 +766,9 @@ export default function Messaging() {
                                         {selectedFiles.map((f, i) => (
                                             <div key={i} className={styles.previewThumb}>
                                                 {f.type.startsWith("image") ? (
-                                                    <img src={createPreviewUrl(f)} alt="preview" />
+                                                    <img src={previewUrls[i]} alt="preview" />
                                                 ) : (
-                                                    <video src={createPreviewUrl(f)} />
+                                                    <video src={previewUrls[i]} />
                                                 )}
                                                 <button onClick={() => removeFile(i)}>×</button>
                                             </div>

--- a/frontend/src/pages/profile/index.jsx
+++ b/frontend/src/pages/profile/index.jsx
@@ -4,7 +4,7 @@ import { Base_Url, clientServer } from '@/config'
 import { useDispatch, useSelector } from 'react-redux'
 import { getAboutUser, getConnectionRequest, updateUserProfile } from '@/config/redux/action/authAction'
 import { useRouter } from 'next/router'
-import { getAllPosts, getBookmarkedPosts, getLikedPosts } from '@/config/redux/action/postAction'
+import { getPostsByUsername, getBookmarkedPosts, getLikedPosts } from '@/config/redux/action/postAction'
 import DashboardLayout from '@/layout/DashboardLayout' // Added for Tablet/Mobile logic
 import Skeleton from '@/Components/ui/Skeleton'
 import { Camera, Pencil, ArrowRight, Plus, X, Heart, Bookmark } from 'lucide-react'
@@ -121,23 +121,27 @@ export default function Profile() {
     const token = localStorage.getItem('token');
 
     if (token) {
-      // 1. Fetch user profile, connection requests, and posts immediately
-      // using the token directly from localStorage
+      // 1. Fetch user profile and connection requests immediately using the
+      // token directly from localStorage
       dispatch(getAboutUser());
       dispatch(getConnectionRequest());
-      dispatch(getAllPosts());
     } else {
       // 2. No token? Redirect to login immediately
       router.push('/login');
     }
   }, [dispatch, router]); // Dependency array should be stable
+
+  // Was filtering one page of the engagement-ranked global feed by user id —
+  // your own posts that didn't rank into that page were invisible on your
+  // own profile. Fetches your real posts directly instead, once the
+  // username is known (getAboutUser resolves it above).
+  const username = userProfile?.userId?.username;
+  useEffect(() => {
+    if (username) dispatch(getPostsByUsername({ username }));
+  }, [dispatch, username]);
+
   const tokenExists = typeof window !== 'undefined' ? !!localStorage.getItem('token') : false;
-  const userPosts = useMemo(() => {
-    if (postState.posts && userProfile?.userId?._id) { // Added optional chaining
-      return postState.posts.filter(post => post.userId?._id === userProfile.userId._id);
-    }
-    return [];
-  }, [postState.posts, userProfile?.userId?._id]);
+  const userPosts = postState.userPosts || [];
 
   const recentPosts = userPosts.slice(0, 3);
   const hasMorePosts = userPosts.length > 3;

--- a/frontend/src/pages/search/index.jsx
+++ b/frontend/src/pages/search/index.jsx
@@ -30,6 +30,86 @@ function saveRecentSearch(query) {
     return next;
 }
 
+// Was defined inside Search() — a fresh function identity every render, so
+// React remounted every card (resetting requestStatus back to null) on any
+// re-render of the parent, including every keystroke in the search box.
+// That let the same "Connect" click fire twice: the button visually reset
+// to its un-pressed state a moment after actually sending the request.
+function UserCard({ user }) {
+    const router = useRouter();
+    const toast = useToast();
+    const [requestStatus, setRequestStatus] = useState(null); // null, 'pending', 'sent'
+    const [loadingConn, setLoadingConn] = useState(false);
+
+    const navToProfile = () => router.push(`/view_profile/${user.username}`);
+
+    const handleConnect = async (e) => {
+        e.stopPropagation(); // Prevent card click
+        setLoadingConn(true);
+        try {
+            await clientServer.post('/user/send_connection_request', {
+                connectionId: user._id
+            });
+            setRequestStatus('sent');
+            toast.success(`Request sent to ${user.name}`);
+        } catch (error) {
+            console.error("Connection request failed", error);
+            const msg = error.response?.data?.message || "Failed to connect";
+            if (msg.includes("Already connected") || msg.includes("already pending")) {
+                setRequestStatus('sent'); // Treat as sent/connected
+            } else {
+                toast.error(msg);
+            }
+        } finally {
+            setLoadingConn(false);
+        }
+    };
+
+    return (
+        <div className={styles.card} onClick={navToProfile}>
+            <div className={styles.cardHeader}>
+                <img
+                    src={user.profilePicture || '/default-avatar.svg'}
+                    alt={user.name}
+                    className={styles.avatar}
+                />
+                <div className={styles.userInfo}>
+                    <h3 className={styles.name}>{user.name}</h3>
+                    <p className={styles.username}>@{user.username}</p>
+                </div>
+
+                <button
+                    className={`${styles.connectBtn} ${requestStatus === 'sent' ? styles.sent : ''} mt-btn-lift`}
+                    onClick={handleConnect}
+                    disabled={loadingConn || requestStatus === 'sent'}
+                >
+                    {loadingConn ? (
+                        <span className={styles.loadingDot}>•</span>
+                    ) : requestStatus === 'sent' ? (
+                        <Check className={styles.btnIcon} />
+                    ) : (
+                        <UserPlus className={styles.btnIcon} />
+                    )}
+                </button>
+            </div>
+
+            <div className={styles.cardBody}>
+                {user.profile?.bio && (
+                    <p className={styles.bio}>{user.profile.bio.substring(0, 60)}...</p>
+                )}
+
+                {user.profile?.skills?.length > 0 && (
+                    <div className={styles.skills}>
+                        {user.profile.skills.slice(0, 2).map((skill, index) => (
+                            <span key={index} className={styles.skillTag}>{skill}</span>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
 const Search = () => {
     const router = useRouter();
     const toast = useToast();
@@ -107,84 +187,6 @@ const Search = () => {
         if (localQuery.trim()) {
             router.push(`/search?q=${encodeURIComponent(localQuery.trim())}`);
         }
-    };
-
-    const navToProfile = (username) => {
-        router.push(`/view_profile/${username}`);
-    }
-
-    // Extracted UserCard component to handle its own connection state
-    const UserCard = ({ user }) => {
-        const [requestStatus, setRequestStatus] = useState(null); // null, 'pending', 'sent'
-        const [loadingConn, setLoadingConn] = useState(false);
-
-        const handleConnect = async (e) => {
-            e.stopPropagation(); // Prevent card click
-            setLoadingConn(true);
-            try {
-                await clientServer.post('/user/send_connection_request', {
-                    connectionId: user._id
-                });
-                setRequestStatus('sent');
-                toast.success(`Request sent to ${user.name}`);
-            } catch (error) {
-                console.error("Connection request failed", error);
-                const msg = error.response?.data?.message || "Failed to connect";
-                if (msg.includes("Already connected") || msg.includes("already pending")) {
-                    setRequestStatus('sent'); // Treat as sent/connected
-                } else {
-                    toast.error(msg);
-                }
-            } finally {
-                setLoadingConn(false);
-            }
-        };
-
-        return (
-            <div className={styles.card} onClick={() => navToProfile(user.username)}>
-                <div className={styles.cardHeader}>
-                    <img
-                        src={user.profilePicture || '/default-avatar.svg'}
-                        alt={user.name}
-                        className={styles.avatar}
-                    />
-                    <div className={styles.userInfo}>
-                        <h3 className={styles.name}>{user.name}</h3>
-                        <p className={styles.username}>@{user.username}</p>
-                    </div>
-
-                    <button
-                        className={`${styles.connectBtn} ${requestStatus === 'sent' ? styles.sent : ''} mt-btn-lift`}
-                        onClick={handleConnect}
-                        disabled={loadingConn || requestStatus === 'sent'}
-                    >
-                        {loadingConn ? (
-                            <span className={styles.loadingDot}>•</span>
-                        ) : requestStatus === 'sent' ? (
-                            <Check className={styles.btnIcon} />
-                        ) : (
-                            <UserPlus className={styles.btnIcon} />
-                        )}
-                    </button>
-                </div>
-
-                <div className={styles.cardBody}>
-                    {/* Match reason removed as requested */}
-
-                    {user.profile?.bio && (
-                        <p className={styles.bio}>{user.profile.bio.substring(0, 60)}...</p>
-                    )}
-
-                    {user.profile?.skills?.length > 0 && (
-                        <div className={styles.skills}>
-                            {user.profile.skills.slice(0, 2).map((skill, index) => (
-                                <span key={index} className={styles.skillTag}>{skill}</span>
-                            ))}
-                        </div>
-                    )}
-                </div>
-            </div>
-        );
     };
 
     return (

--- a/frontend/src/pages/view_profile/[username].jsx
+++ b/frontend/src/pages/view_profile/[username].jsx
@@ -4,7 +4,7 @@ import styles from './styles.module.css'
 import DashboardLayout from '@/layout/DashboardLayout'
 import { useRouter } from 'next/router'
 import { useDispatch, useSelector } from 'react-redux'
-import { getAllPosts } from '@/config/redux/action/postAction'
+import { getPostsByUsername } from '@/config/redux/action/postAction'
 import { downloadResume, getConnectionRequest, sendConnectionRequest } from '@/config/redux/action/authAction'
 import serverAxios from '@/config/serverAxios'
 import { UserPlus, Check, Download, ArrowRight } from 'lucide-react'
@@ -21,33 +21,6 @@ export default function viewProfilePage({ userProfile }) {
     const [isCurrentUserInConnection, setIsCurrentUserInConnection] = useState(false)
     const [isConnectionNull, setConnectionNull] = useState(true)
     const [connectionStatus, setConnectionStatus] = useState(undefined); // NEW STATE
-
-    if (!userProfile) {
-        return (
-            <DashboardLayout>
-                <div style={{ textAlign: "center", padding: "60px 20px", color: "var(--mt-ink)" }}>
-                    <h2 style={{ fontFamily: "var(--mt-font-display)", fontWeight: 500 }}>User not found</h2>
-                    <p style={{ color: "var(--mt-ink2)" }}>The profile you are looking for does not exist or may have been removed.</p>
-                    <button
-                        onClick={() => router.push('/dashboard')}
-                        style={{
-                            marginTop: "20px",
-                            padding: "10px 22px",
-                            background: "var(--mt-grad)",
-                            color: "#fff",
-                            border: "none",
-                            borderRadius: "999px",
-                            fontWeight: 600,
-                            fontSize: "13.5px",
-                            cursor: "pointer"
-                        }}
-                    >
-                        Go to Dashboard
-                    </button>
-                </div>
-            </DashboardLayout>
-        );
-    }
 
     useEffect(() => {
         const connections = userState.connection;
@@ -78,17 +51,23 @@ export default function viewProfilePage({ userProfile }) {
     useEffect(() => {
         const token = localStorage.getItem('token');
         if (token) {
-            dispatch(getAllPosts())
             dispatch(getConnectionRequest())
         }
     }, [dispatch]);
 
+    // Was filtering one page of the engagement-ranked global feed by
+    // username — someone's own posts that didn't rank into that page were
+    // invisible on their own profile. Queries their actual posts directly.
     useEffect(() => {
-        if (postState.posts) {
-            let posts = postState.posts.filter((post) => post.userId.username === router.query.username)
-            setUserPost(posts)
+        const token = localStorage.getItem('token');
+        if (token && router.query.username) {
+            dispatch(getPostsByUsername({ username: router.query.username }));
         }
-    }, [postState.posts, router.query.username])
+    }, [dispatch, router.query.username]);
+
+    useEffect(() => {
+        setUserPost(postState.userPosts || []);
+    }, [postState.userPosts])
 
     useEffect(() => {
         const connections = userState.connection;
@@ -109,6 +88,38 @@ export default function viewProfilePage({ userProfile }) {
             }
         }
     }, [userState.connection, userProfile?.userId?._id]);
+
+    // Placed after every hook above (not before, as this used to be) — a
+    // conditional `return` before some of this component's hooks meant
+    // client-side-navigating from a valid profile to a missing one reused
+    // the same component instance with fewer hooks called on the next
+    // render, which React throws on ("Rendered fewer hooks than expected").
+    if (!userProfile) {
+        return (
+            <DashboardLayout>
+                <div style={{ textAlign: "center", padding: "60px 20px", color: "var(--mt-ink)" }}>
+                    <h2 style={{ fontFamily: "var(--mt-font-display)", fontWeight: 500 }}>User not found</h2>
+                    <p style={{ color: "var(--mt-ink2)" }}>The profile you are looking for does not exist or may have been removed.</p>
+                    <button
+                        onClick={() => router.push('/dashboard')}
+                        style={{
+                            marginTop: "20px",
+                            padding: "10px 22px",
+                            background: "var(--mt-grad)",
+                            color: "#fff",
+                            border: "none",
+                            borderRadius: "999px",
+                            fontWeight: 600,
+                            fontSize: "13.5px",
+                            cursor: "pointer"
+                        }}
+                    >
+                        Go to Dashboard
+                    </button>
+                </div>
+            </DashboardLayout>
+        );
+    }
 
     const recentPosts = userPost.slice(0, 3);
     const hasMorePosts = userPost.length > 3;
@@ -197,7 +208,7 @@ export default function viewProfilePage({ userProfile }) {
                             userProfile.education.map((edu, idx) => (
                                 <div key={idx} className={styles.infoItem}>
                                     <h4>{edu.school}</h4>
-                                    <p>{edu.degree}  {edu.fieldOfStudy}</p>
+                                    <p>{edu.degree}  {edu.feildStudy}</p>
                                 </div>
                             ))
                         ) : <p className={styles.noDataText}>No education listed.</p>}


### PR DESCRIPTION
## Summary
- Backend: verifyToken-before-multer ordering fixed on all upload routes (was billing/storing files before auth check), Cloudinary video support fixed, unauthenticated email-based account enumeration in search closed, sendMessage now requires an accepted connection + validates the id, deleteMessages fixed to not leak into the other participant's view, report/story defensive fixes.
- New GET /posts/user/:username endpoint — profile/activity/view_profile no longer filter one page of the global ranked feed (which made a user's own posts frequently invisible on their own profile).
- Messaging: fixed long-press-to-select immediately self-cancelling (deletion was unusable), added error handling to delete flows + removed dead code, fixed a blob URL memory leak, fixed read receipts flipping the wrong conversation's ticks, added live sidebar conversation updates.
- Fixed a hooks-order crash in view_profile, a fieldOfStudy/feildStudy typo, and search's Connect button silently resetting due to a component being redefined every render.

## Test plan
- [ ] Long-press a message in a chat, confirm it stays selected
- [ ] Post several items on a test account, confirm they all show on that account's own profile/activity page
- [ ] Search someone by email while logged out — confirm no results/enumeration
- [ ] Attach a video in a chat message — confirm it uploads