### PR TITLE
feat: on-brand blast loader replacing plain spinner/placeholder text

### DIFF
--- a/frontend/src/Components/ui/BlastLoader.jsx
+++ b/frontend/src/Components/ui/BlastLoader.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styles from './BlastLoader.module.css';
+
+/** On-brand loading indicator: the starburst mark as a spinning, pulsing
+ * gradient ring with a hollow center — used wherever the app previously
+ * showed a plain "...loading" text or a generic spinner. */
+export default function BlastLoader({ size = 64 }) {
+  return (
+    <div className={styles.blast} style={{ width: size, height: size }}>
+      <div className={styles.ring} />
+      <div className={styles.hole} />
+    </div>
+  );
+}

--- a/frontend/src/Components/ui/BlastLoader.module.css
+++ b/frontend/src/Components/ui/BlastLoader.module.css
@@ -1,0 +1,50 @@
+.blast {
+    position: relative;
+    display: inline-block;
+}
+
+/* The starburst mark used as a mask over a spinning brand-gradient sweep —
+   same PNG as the favicon, just recolored/animated via CSS mask instead of
+   needing a second art asset. */
+.ring {
+    position: absolute;
+    inset: 0;
+    background: conic-gradient(from 0deg, #0447ff, #7b5cf0, #ff4704, #0447ff);
+    -webkit-mask-image: url('/brand/mitrata-mark.png');
+    mask-image: url('/brand/mitrata-mark.png');
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    mask-position: center;
+    animation: blastSpin 1.6s linear infinite, blastPulse 1.6s ease-in-out infinite;
+}
+
+/* A canvas-colored disc over the center turns the solid star into a hollow
+   ring — the "event horizon" look, dark center with the mark only visible
+   as its outer points. */
+.hole {
+    position: absolute;
+    inset: 30%;
+    border-radius: 50%;
+    background: var(--mt-canvas);
+}
+
+@keyframes blastSpin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@keyframes blastPulse {
+
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.6;
+    }
+}

--- a/frontend/src/Components/ui/PageLoader.jsx
+++ b/frontend/src/Components/ui/PageLoader.jsx
@@ -1,14 +1,12 @@
 import React from 'react';
+import BlastLoader from './BlastLoader';
 
 /** Full-page loading state — swap in for `return null` during an auth/mount
- * check so navigating/refreshing shows a spinner instead of a blank flash. */
+ * check so navigating/refreshing shows the brand loader instead of a blank flash. */
 export default function PageLoader() {
   return (
     <div className="min-h-screen w-full flex items-center justify-center bg-[var(--mt-canvas)]">
-      <div
-        className="size-10 rounded-full border-[3px] border-t-transparent animate-spin"
-        style={{ borderColor: 'var(--mt-accent)', borderTopColor: 'transparent' }}
-      />
+      <BlastLoader />
     </div>
   );
 }

--- a/frontend/src/pages/dashboard/index.jsx
+++ b/frontend/src/pages/dashboard/index.jsx
@@ -11,6 +11,7 @@ import {
 } from "@/config/redux/action/postAction";
 import DashboardLayout from "@/layout/DashboardLayout";
 import PageLoader from "@/Components/ui/PageLoader";
+import BlastLoader from "@/Components/ui/BlastLoader";
 import { useRouter } from "next/router";
 import React, { useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -786,9 +787,11 @@ export default function Dashboard() {
     );
   } else {
     return (
-              <DashboardLayout>
-          <div className="loading">...loading</div>
-        </DashboardLayout>
+      <DashboardLayout>
+        <div className="w-full flex items-center justify-center py-24">
+          <BlastLoader />
+        </div>
+      </DashboardLayout>
     );
   }
 }


### PR DESCRIPTION
Replaces a literal <div>...loading</div> placeholder on dashboard and the plain spinner in PageLoader with a hollow, spinning brand-gradient starburst (reusing the existing mark PNG via CSS mask, no new asset).