### PR TITLE
feat: redesigned Settings/Help&Support/Privacy Policy, fixed loading flashes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@heroicons/react": "^2.2.0",
         "@reduxjs/toolkit": "^2.9.2",
         "axios": "^1.12.2",
         "jsonwebtoken": "^9.0.3",
@@ -214,15 +213,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@heroicons/react": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
-      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,6 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@heroicons/react": "^2.2.0",
     "@reduxjs/toolkit": "^2.9.2",
     "axios": "^1.12.2",
     "jsonwebtoken": "^9.0.3",

--- a/frontend/src/Components/ui/FaqItem.jsx
+++ b/frontend/src/Components/ui/FaqItem.jsx
@@ -1,0 +1,18 @@
+import React, { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import styles from './FaqItem.module.css';
+
+/** One collapsible question/answer row — shared by any FAQ-style list so a
+ * page doesn't need to hand-roll its own open/close state per question. */
+export default function FaqItem({ question, answer }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className={styles.faqItem}>
+      <button className={styles.question} onClick={() => setOpen((o) => !o)} aria-expanded={open}>
+        <span>{question}</span>
+        <ChevronDown className={`${styles.chevron} ${open ? styles.chevronOpen : ''}`} />
+      </button>
+      {open && <p className={styles.answer}>{answer}</p>}
+    </div>
+  );
+}

--- a/frontend/src/Components/ui/FaqItem.module.css
+++ b/frontend/src/Components/ui/FaqItem.module.css
@@ -1,0 +1,43 @@
+.faqItem {
+    border-bottom: 1px solid var(--mt-border);
+}
+
+.faqItem:last-child {
+    border-bottom: none;
+}
+
+.question {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 16px;
+    background: none;
+    border: none;
+    text-align: left;
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--mt-ink);
+    cursor: pointer;
+}
+
+.chevron {
+    width: 18px;
+    height: 18px;
+    color: var(--mt-ink3);
+    flex-shrink: 0;
+    transition: transform 0.2s var(--mt-ease);
+}
+
+.chevronOpen {
+    transform: rotate(180deg);
+}
+
+.answer {
+    padding: 0 16px 16px;
+    margin: 0;
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--mt-ink2);
+}

--- a/frontend/src/Components/ui/SettingsItem.jsx
+++ b/frontend/src/Components/ui/SettingsItem.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { ChevronRight } from 'lucide-react';
+import styles from './SettingsItem.module.css';
+
+/** One row in a Settings-style list: icon, label + sub-label, and either a
+ * chevron (navigates) or a custom control (e.g. the theme selector) on the
+ * right. Used across Settings/Help & Support so every list in that part of
+ * the app shares one row instead of each page re-inlining the same markup. */
+export default function SettingsItem({ icon: Icon, label, sub, onClick, right, badge }) {
+  return (
+    <div className={styles.item} onClick={onClick} role={onClick ? 'button' : undefined}>
+      <div className={styles.iconBox}>
+        <Icon className={styles.icon} />
+      </div>
+      <div className={styles.labelBlock}>
+        <span className={styles.label}>{label}</span>
+        {sub && <span className={styles.sub}>{sub}</span>}
+      </div>
+      {badge > 0 && <span className={styles.badge}>{badge > 9 ? '9+' : badge}</span>}
+      {right || (onClick && <ChevronRight className={styles.arrowIcon} />)}
+    </div>
+  );
+}

--- a/frontend/src/Components/ui/SettingsItem.module.css
+++ b/frontend/src/Components/ui/SettingsItem.module.css
@@ -1,0 +1,71 @@
+.item {
+    display: flex;
+    align-items: center;
+    padding: 14px 16px;
+    cursor: pointer;
+    transition: background 0.2s;
+    border-bottom: 1px solid var(--mt-border);
+}
+
+.item:last-child {
+    border-bottom: none;
+}
+
+.item:hover {
+    background: var(--mt-sunken);
+}
+
+.iconBox {
+    width: 36px;
+    height: 36px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 14px;
+    flex-shrink: 0;
+    background: var(--mt-sunken);
+    color: var(--mt-accent);
+}
+
+.icon {
+    width: 18px;
+    height: 18px;
+}
+
+.labelBlock {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.label {
+    font-size: 13.5px;
+    font-weight: 500;
+    color: var(--mt-ink);
+}
+
+.sub {
+    font-size: 12px;
+    color: var(--mt-ink3);
+    margin-top: 2px;
+}
+
+.arrowIcon {
+    width: 20px;
+    height: 20px;
+    color: var(--mt-ink3);
+    flex-shrink: 0;
+}
+
+.badge {
+    background: var(--mt-danger);
+    color: #fff;
+    font-size: 11px;
+    font-weight: 700;
+    padding: 2px 7px;
+    border-radius: 999px;
+    margin-right: 10px;
+    flex-shrink: 0;
+}

--- a/frontend/src/pages/help_support/HelpSupport.module.css
+++ b/frontend/src/pages/help_support/HelpSupport.module.css
@@ -1,0 +1,132 @@
+.container {
+    max-width: 600px;
+    margin: 0 auto;
+    padding: 24px 20px 100px;
+}
+
+.header {
+    margin-bottom: 24px;
+}
+
+.backBtn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: none;
+    border: none;
+    color: var(--mt-ink2);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    padding: 0;
+    margin-bottom: 12px;
+}
+
+.backIcon {
+    width: 18px;
+    height: 18px;
+}
+
+.title {
+    font-family: var(--mt-font-display);
+    font-size: 32px;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    background: var(--mt-grad);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    display: inline-block;
+}
+
+.sub {
+    color: var(--mt-ink2);
+    font-size: 14px;
+    margin-top: 4px;
+}
+
+.contactCard {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    background: var(--mt-surface);
+    border: 1px solid var(--mt-border);
+    border-radius: 20px;
+    padding: 20px;
+    box-shadow: var(--mt-shadow);
+    margin-bottom: 32px;
+}
+
+.contactIconBox {
+    width: 48px;
+    height: 48px;
+    border-radius: 14px;
+    background: var(--mt-grad-soft);
+    color: var(--mt-accent);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.contactText h3 {
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--mt-ink);
+    margin: 0 0 2px;
+}
+
+.contactText p {
+    font-size: 12.5px;
+    color: var(--mt-ink2);
+    margin: 0;
+}
+
+.emailBtn {
+    margin-left: auto;
+    flex-shrink: 0;
+    background: var(--mt-grad);
+    color: #fff;
+    border: none;
+    padding: 9px 18px;
+    border-radius: 999px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.sectionTitle {
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--mt-ink3);
+    margin-bottom: 12px;
+    padding-left: 12px;
+    letter-spacing: 0.08em;
+}
+
+.group {
+    background: var(--mt-surface);
+    border-radius: 16px;
+    overflow: hidden;
+    margin-bottom: 24px;
+    box-shadow: var(--mt-shadow);
+    border: 1px solid var(--mt-border);
+}
+
+@media (max-width: 640px) {
+    .container {
+        padding: 16px 16px 100px;
+    }
+
+    .contactCard {
+        flex-wrap: wrap;
+    }
+
+    .emailBtn {
+        margin-left: 0;
+        width: 100%;
+        text-align: center;
+    }
+}

--- a/frontend/src/pages/help_support/index.jsx
+++ b/frontend/src/pages/help_support/index.jsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import DashboardLayout from '@/layout/DashboardLayout';
+import FaqItem from '@/Components/ui/FaqItem';
+import SettingsItem from '@/Components/ui/SettingsItem';
+import styles from './HelpSupport.module.css';
+import { ChevronLeft, Mail, ShieldCheck } from 'lucide-react';
+
+export const SUPPORT_EMAIL = 'mitrata.llp@gmail.com';
+
+const FAQS = [
+  {
+    q: 'How do I reset my password?',
+    a: "On the login page, choose \"Forgot password?\", enter your email, and we'll send you a one-time code to set a new password.",
+  },
+  {
+    q: "I didn't get my verification code — what now?",
+    a: "Check spam/junk first. If it's genuinely not arriving, wait for the resend cooldown to clear and tap \"Resend code\" on the verification screen.",
+  },
+  {
+    q: 'How do I add or switch between multiple accounts?',
+    a: 'Open the account switcher from the sidebar (or the profile menu on mobile) and choose "Add another account" — your other accounts stay signed in so switching back is instant.',
+  },
+  {
+    q: "Someone I don't know can message me — is that expected?",
+    a: 'No — messaging only works between accepted connections. If this happens, please report it to us using the contact option below.',
+  },
+  {
+    q: 'How do I permanently delete my account?',
+    a: 'Go to Settings → Danger Zone → "Delete my account permanently". This removes your profile, posts, messages, connections and media, and cannot be undone.',
+  },
+];
+
+export default function HelpSupport() {
+  const router = useRouter();
+  return (
+    <DashboardLayout>
+      <div className={styles.container}>
+        <header className={styles.header}>
+          <button className={styles.backBtn} onClick={() => router.back()}>
+            <ChevronLeft className={styles.backIcon} />
+            Back
+          </button>
+          <h1 className={styles.title}>Help & Support</h1>
+          <p className={styles.sub}>Answers to common questions, or reach us directly.</p>
+        </header>
+
+        <div className={styles.contactCard}>
+          <div className={styles.contactIconBox}>
+            <Mail size={22} strokeWidth={1.8} />
+          </div>
+          <div className={styles.contactText}>
+            <h3>Email us</h3>
+            <p>We typically reply within a day or two.</p>
+          </div>
+          <a className={styles.emailBtn} href={`mailto:${SUPPORT_EMAIL}`}>
+            {SUPPORT_EMAIL}
+          </a>
+        </div>
+
+        <div className={styles.sectionTitle}>Frequently asked questions</div>
+        <div className={`${styles.group} mt-enter`}>
+          {FAQS.map((item) => (
+            <FaqItem key={item.q} question={item.q} answer={item.a} />
+          ))}
+        </div>
+
+        <div className={styles.sectionTitle}>More</div>
+        <div className={`${styles.group} mt-enter`}>
+          <SettingsItem
+            icon={ShieldCheck}
+            label="Privacy Policy"
+            sub="How we handle your data"
+            onClick={() => router.push('/privacy_policy')}
+          />
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/frontend/src/pages/messaging/[username].jsx
+++ b/frontend/src/pages/messaging/[username].jsx
@@ -12,6 +12,8 @@ import { useNotification } from "@/Components/NotificationProvider";
 import { useCall } from "@/Components/CallProvider";
 import { compressImage } from "@/utils/imageProcessing";
 import EmptyState from "@/Components/ui/EmptyState";
+import PageLoader from "@/Components/ui/PageLoader";
+import BlastLoader from "@/Components/ui/BlastLoader";
 import { ArrowLeft, Search, Phone, Video, MoreVertical, Trash2, Plus, Send, Download, X, MessageCircle, UsersRound, Check, CheckCheck } from "lucide-react";
 
 export default function Messaging() {
@@ -36,6 +38,16 @@ export default function Messaging() {
     const [selectedMessages, setSelectedMessages] = useState([]);
     const [showDeleteMenu, setShowDeleteMenu] = useState(false);
     const [isTyping, setIsTyping] = useState(false);
+    // The sidebar's "No connections yet" empty state used to flash before
+    // the actual connections/conversations fetch resolved (there was no
+    // independent loaded flag — connections.length === 0 was true both
+    // before AND during loading, so they looked identical).
+    const [sidebarLoaded, setSidebarLoaded] = useState(false);
+    // Dedicated to the active-chat fetch specifically — the reducer's
+    // isLoading is shared with sendMessage's pending/fulfilled too, so using
+    // that here would blank the whole conversation every time you send a
+    // message, not just while the initial history is loading.
+    const [chatLoading, setChatLoading] = useState(false);
     const deleteMenuRef = useRef(null);
     const longPressTimer = useRef(null);
     const fileInputRef = useRef(null);
@@ -67,9 +79,12 @@ export default function Messaging() {
         }
 
         if (!authState.user) dispatch(getAboutUser());
-        if (authState.connectionRequest.length === 0) {
-            dispatch(getMyConnectionRequests());
-        }
+
+        const connReqPromise = authState.connectionRequest.length === 0
+            ? dispatch(getMyConnectionRequests())
+            : Promise.resolve();
+        Promise.allSettled([connReqPromise, dispatch(getConversations())])
+            .then(() => setSidebarLoaded(true));
     }, [dispatch, authState.user, authState.connectionRequest.length, mounted, router]);
 
     useEffect(() => {
@@ -103,11 +118,8 @@ export default function Messaging() {
     // Real conversation previews/unread counts (replaces the old hardcoded
     // "Click to chat" placeholder) — connections with an actual conversation
     // sort to the top by recency; message-less connections stay after, in
-    // their existing order.
-    useEffect(() => {
-        dispatch(getConversations());
-    }, [dispatch]);
-
+    // their existing order. Fetched together with connections above (see
+    // the auth-rehydration effect and sidebarLoaded).
     const conversationByUserId = useMemo(() => {
         const map = {};
         conversations.forEach((c) => { map[c.userId] = c; });
@@ -192,7 +204,8 @@ export default function Messaging() {
     /* -------------------- FETCH CHAT -------------------- */
     useEffect(() => {
         if (activeChatUser?.userId?._id) {
-            dispatch(getMessages({ receiverId: activeChatUser.userId._id }));
+            setChatLoading(true);
+            dispatch(getMessages({ receiverId: activeChatUser.userId._id })).finally(() => setChatLoading(false));
             dispatch(markMessagesRead({ senderId: activeChatUser.userId._id }));
         } else {
             dispatch(resetMessages());
@@ -459,7 +472,7 @@ export default function Messaging() {
     }, [selectedMessages, messages, authState.user]);
 
     /* -------------------- PREVENT FLASH -------------------- */
-    if (!mounted) return null;
+    if (!mounted) return <PageLoader />;
 
     /* -------------------- UI -------------------- */
     return (
@@ -479,7 +492,11 @@ export default function Messaging() {
                     </div>
 
                     <div className={styles.connectionsList}>
-                        {connections.length === 0 ? (
+                        {!sidebarLoaded ? (
+                            <div className="w-full flex items-center justify-center py-16">
+                                <BlastLoader size={48} />
+                            </div>
+                        ) : connections.length === 0 ? (
                             <EmptyState
                                 icon={UsersRound}
                                 title="No connections yet"
@@ -662,7 +679,11 @@ export default function Messaging() {
 
                             {/* MESSAGES AREA */}
                             <div className={styles.messagesArea}>
-                                {!showSearchModal && messages.length === 0 && (
+                                {chatLoading ? (
+                                    <div className="w-full flex items-center justify-center py-16">
+                                        <BlastLoader size={48} />
+                                    </div>
+                                ) : !showSearchModal && messages.length === 0 && (
                                     <EmptyState
                                         icon={MessageCircle}
                                         title="No messages yet"

--- a/frontend/src/pages/my_network/index.jsx
+++ b/frontend/src/pages/my_network/index.jsx
@@ -9,6 +9,7 @@ import { useRouter } from 'next/router';
 import { Phone, MessageCircle, Check, X, UsersRound, Inbox, SendHorizontal } from 'lucide-react';
 import EmptyState from '@/Components/ui/EmptyState';
 import PageLoader from '@/Components/ui/PageLoader';
+import BlastLoader from '@/Components/ui/BlastLoader';
 import { useCall } from '@/Components/CallProvider';
 
 export default function MyNetwork() {
@@ -19,14 +20,21 @@ export default function MyNetwork() {
 
     const [activeTab, setActiveTab] = useState('connections');
     const [isMounted, setIsMounted] = useState(false);
+    // isMounted only ever meant "has this component rendered once" — it flips
+    // true well before the connection/request data actually arrives, so every
+    // tab showed its "No connections/requests yet" empty state for a beat
+    // before the real data replaced it. This tracks the actual fetch.
+    const [dataLoaded, setDataLoaded] = useState(false);
     const toast = useToast();
     const { callUser } = useCall();
 
     const refreshData = useCallback(() => {
         const token = localStorage.getItem("token");
         if (token) {
-            dispatch(getMyConnectionRequests());
-            dispatch(getConnectionRequest());
+            Promise.allSettled([
+                dispatch(getMyConnectionRequests()),
+                dispatch(getConnectionRequest())
+            ]).then(() => setDataLoaded(true));
         }
     }, [dispatch]);
 
@@ -123,6 +131,11 @@ export default function MyNetwork() {
                     </div>
 
                     <div className={styles.contentArea}>
+                        {!dataLoaded ? (
+                            <div className="w-full flex items-center justify-center py-16">
+                                <BlastLoader size={48} />
+                            </div>
+                        ) : <>
                         {activeTab === 'connections' && (
                             <div className={styles.connectionsList}>
                                 {myConnections.length === 0 ? (
@@ -225,6 +238,7 @@ export default function MyNetwork() {
                                 )}
                             </div>
                         )}
+                        </>}
                     </div>
                 </div>
             </DashboardLayout>

--- a/frontend/src/pages/privacy_policy/PrivacyPolicy.module.css
+++ b/frontend/src/pages/privacy_policy/PrivacyPolicy.module.css
@@ -1,130 +1,111 @@
 .container {
-    max-width: 800px;
+    max-width: 720px;
     margin: 0 auto;
-    padding: 20px;
-    font-family: 'Inter', -apple-system, sans-serif;
-    color: #334155;
-    background: #fff;
-    min-height: 100vh;
-}
-
-:global(.dark) .container {
-    background: #0f172a;
-    color: #e2e8f0;
+    padding: 24px 20px 100px;
+    color: var(--mt-ink);
 }
 
 .header {
-    display: flex;
-    align-items: center;
-    margin-bottom: 40px;
-    padding-bottom: 20px;
-    border-bottom: 1px solid #e2e8f0;
-}
-
-:global(.dark) .header {
-    border-bottom: 1px solid #334155;
+    margin-bottom: 32px;
 }
 
 .backBtn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
     background: none;
     border: none;
-    display: flex;
-    align-items: center;
-    color: #64748b;
+    color: var(--mt-ink2);
+    font-size: 13px;
+    font-weight: 500;
     cursor: pointer;
-    font-size: 16px;
-    padding: 8px 16px 8px 0;
-    transition: color 0.2s;
-}
-
-:global(.dark) .backBtn {
-    color: #94a3b8;
-}
-
-.backBtn:hover {
-    color: #3b82f6;
+    padding: 0;
+    margin-bottom: 12px;
 }
 
 .backIcon {
-    width: 20px;
-    height: 20px;
-    margin-right: 4px;
+    width: 18px;
+    height: 18px;
 }
 
 .title {
-    flex: 1;
-    text-align: center;
-    font-size: 24px;
-    font-weight: 700;
-    margin: 0;
-    margin-right: 60px;
-    /* Balance back button width */
-}
-
-.content {
-    line-height: 1.6;
+    font-family: var(--mt-font-display);
+    font-size: 32px;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    background: var(--mt-grad);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    display: inline-block;
 }
 
 .lastUpdated {
-    color: #94a3b8;
-    font-size: 14px;
-    margin-bottom: 40px;
-    font-style: italic;
+    color: var(--mt-ink3);
+    font-size: 13px;
+    margin-top: 6px;
 }
 
 .section {
-    margin-bottom: 40px;
+    background: var(--mt-surface);
+    border: 1px solid var(--mt-border);
+    border-radius: 16px;
+    box-shadow: var(--mt-shadow);
+    padding: 20px;
+    margin-bottom: 20px;
 }
 
 .section h2 {
-    font-size: 20px;
-    color: #1e293b;
-    margin-bottom: 16px;
-    border-left: 4px solid #3b82f6;
-    padding-left: 12px;
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--mt-ink);
+    margin: 0 0 12px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
 }
 
-:global(.dark) .section h2 {
-    color: #f8fafc;
+.sectionNum {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: var(--mt-grad-soft);
+    color: var(--mt-accent);
+    font-size: 11px;
+    font-weight: 800;
+    flex-shrink: 0;
 }
 
 .section p {
-    margin-bottom: 16px;
-    font-size: 16px;
+    margin: 0 0 12px;
+    font-size: 13.5px;
+    line-height: 1.65;
+    color: var(--mt-ink2);
 }
 
 .section ul {
     list-style-type: disc;
-    padding-left: 24px;
-    margin-bottom: 16px;
+    padding-left: 20px;
+    margin: 0 0 12px;
 }
 
 .section li {
-    margin-bottom: 8px;
+    margin-bottom: 6px;
+    font-size: 13.5px;
+    line-height: 1.6;
+    color: var(--mt-ink2);
 }
 
 .section a {
-    color: #3b82f6;
-    text-decoration: none;
-}
-
-.section a:hover {
-    text-decoration: underline;
+    color: var(--mt-accent);
+    font-weight: 600;
 }
 
 @media (max-width: 640px) {
     .container {
-        padding: 16px;
-    }
-
-    .title {
-        font-size: 20px;
-        margin-right: 0;
-    }
-
-    .header {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 16px;
+        padding: 16px 16px 100px;
     }
 }

--- a/frontend/src/pages/privacy_policy/index.jsx
+++ b/frontend/src/pages/privacy_policy/index.jsx
@@ -1,71 +1,105 @@
 import React from 'react';
 import { useRouter } from 'next/router';
 import styles from './PrivacyPolicy.module.css';
-import { ChevronLeftIcon } from '@heroicons/react/24/outline';
+import { ChevronLeft } from 'lucide-react';
 import UserLayout from '@/layout/userLayout';
+
+export const SUPPORT_EMAIL = 'mitrata.llp@gmail.com';
+
+// Data-driven instead of six near-identical <section> blocks — also makes
+// it obvious at a glance which numbered section is which when this needs
+// updating later.
+const SECTIONS = [
+    {
+        title: 'Introduction',
+        body: (
+            <p>Welcome to Mitrata. We value your privacy and are committed to protecting your personal information. This Privacy Policy explains how we collect, use, and share your data when you use our platform.</p>
+        ),
+    },
+    {
+        title: 'Information We Collect',
+        body: (
+            <ul>
+                <li><strong>Account information:</strong> name, username, email address, and profile picture.</li>
+                <li><strong>Content:</strong> posts, comments, reactions, stories, and messages you send.</li>
+                <li><strong>Usage data:</strong> how you interact with our services, including device information and connection data.</li>
+            </ul>
+        ),
+    },
+    {
+        title: 'How We Use Your Information',
+        body: (
+            <>
+                <p>We use your data to:</p>
+                <ul>
+                    <li>Provide and improve our services.</li>
+                    <li>Personalize your experience.</li>
+                    <li>Facilitate communication between users (messaging, voice/video calls).</li>
+                    <li>Ensure the safety and security of our platform.</li>
+                </ul>
+            </>
+        ),
+    },
+    {
+        title: 'Data Sharing',
+        body: (
+            <>
+                <p>We do not sell your personal data. We may share information with:</p>
+                <ul>
+                    <li><strong>Service providers</strong> who help us operate the platform (e.g., cloud hosting, media storage, email delivery).</li>
+                    <li><strong>Legal authorities</strong>, if required by law or to protect our rights.</li>
+                </ul>
+            </>
+        ),
+    },
+    {
+        title: 'Your Choices',
+        body: (
+            <p>
+                You can update your profile information at any time via Settings.
+                You can also permanently delete your account yourself — no need to
+                contact us — from Settings → Danger Zone → &ldquo;Delete my account
+                permanently&rdquo;. This removes your profile, posts, messages,
+                connections, and media, and cannot be undone.
+            </p>
+        ),
+    },
+    {
+        title: 'Contact Us',
+        body: (
+            <p>
+                If you have questions about this policy, please contact us at{' '}
+                <a href={`mailto:${SUPPORT_EMAIL}`}>{SUPPORT_EMAIL}</a>.
+            </p>
+        ),
+    },
+];
 
 export default function PrivacyPolicy() {
     const router = useRouter();
 
     return (
         <UserLayout>
-        <div className={styles.container}>
-            <div className={styles.header}>
-                <button onClick={() => router.back()} className={styles.backBtn}>
-                    <ChevronLeftIcon className={styles.backIcon} />
-                    Back
-                </button>
-                <h1 className={styles.title}>Privacy Policy</h1>
+            <div className={styles.container}>
+                <header className={styles.header}>
+                    <button className={styles.backBtn} onClick={() => router.back()}>
+                        <ChevronLeft className={styles.backIcon} />
+                        Back
+                    </button>
+                    <h1 className={styles.title}>Privacy Policy</h1>
+                    <p className={styles.lastUpdated}>Last updated: February 20, 2026</p>
+                </header>
+
+                {SECTIONS.map((section, idx) => (
+                    <section className={styles.section} key={section.title}>
+                        <h2>
+                            <span className={styles.sectionNum}>{idx + 1}</span>
+                            {section.title}
+                        </h2>
+                        {section.body}
+                    </section>
+                ))}
             </div>
-
-            <div className={styles.content}>
-                <p className={styles.lastUpdated}>Last Updated: February 20, 2026</p>
-
-                <section className={styles.section}>
-                    <h2>1. Introduction</h2>
-                    <p>Welcome to SocialMedia. We value your privacy and are committed to protecting your personal information. This Privacy Policy explains how we collect, use, and share your data when you use our platform.</p>
-                </section>
-
-                <section className={styles.section}>
-                    <h2>2. Information We Collect</h2>
-                    <ul>
-                        <li><strong>Account Information:</strong> Name, username, email address, and profile picture.</li>
-                        <li><strong>Content:</strong> Posts, comments, likes, and messages you send.</li>
-                        <li><strong>Usage Data:</strong> Information about how you interact with our services, including device information and connection data.</li>
-                    </ul>
-                </section>
-
-                <section className={styles.section}>
-                    <h2>3. How We Use Your Information</h2>
-                    <p>We use your data to:</p>
-                    <ul>
-                        <li>Provide and improve our services.</li>
-                        <li>Personalize your experience.</li>
-                        <li>Facilitate communication between users (messaging, voice calls).</li>
-                        <li>Ensure the safety and security of our platform.</li>
-                    </ul>
-                </section>
-
-                <section className={styles.section}>
-                    <h2>4. Data Sharing</h2>
-                    <p>We do not sell your personal data. We may share information with:</p>
-                    <ul>
-                        <li><strong>Service Providers:</strong> Who help us operate the platform (e.g., cloud hosting, image storage).</li>
-                        <li><strong>Legal Authorities:</strong> If required by law or to protect our rights.</li>
-                    </ul>
-                </section>
-
-                <section className={styles.section}>
-                    <h2>5. Your Choices</h2>
-                    <p>You can update your profile information at any time via Settings. You can also delete your account by contacting support.</p>
-                </section>
-
-                <section className={styles.section}>
-                    <h2>6. Contact Us</h2>
-                    <p>If you have questions about this policy, please contact us at <a href="mailto:support@mitrata.app">support@mitrata.app</a>.</p>
-                </section>
-            </div>
-        </div>
         </UserLayout>
     );
 }

--- a/frontend/src/pages/settings/index.jsx
+++ b/frontend/src/pages/settings/index.jsx
@@ -13,8 +13,13 @@ import {
     CircleHelp,
     LogOut,
     Trash2,
+    UsersRound,
+    Bell,
+    Search,
 } from 'lucide-react';
 import DashboardLayout from '@/layout/DashboardLayout';
+import SettingsItem from '@/Components/ui/SettingsItem';
+import { useNotification } from '@/Components/NotificationProvider';
 
 const DELETE_CONFIRM_WORD = 'DELETE';
 
@@ -23,6 +28,7 @@ export default function Settings() {
     const dispatch = useDispatch();
     const toast = useToast();
     const { user } = useSelector(state => state.auth);
+    const { unreadCount } = useNotification();
     const [theme, setTheme] = useState('system'); // light, dark, system
     const [showDeleteModal, setShowDeleteModal] = useState(false);
     const [deletePassword, setDeletePassword] = useState('');
@@ -93,6 +99,34 @@ export default function Settings() {
 
                 {/* Settings Groups */}
 
+                {/* Quick Access — some pages (My Network, notably) never had a
+                    direct link on mobile: no bottom-bar slot, no menu entry,
+                    only reachable by chance through another page's button.
+                    Centralizing shortcuts here means there's always at least
+                    one guaranteed way to find them, on any screen size. */}
+                <div className={styles.sectionTitle}>Quick Access</div>
+                <div className={`${styles.group} mt-enter`} style={{ animationDelay: '30ms' }}>
+                    <SettingsItem
+                        icon={UsersRound}
+                        label="My Network"
+                        sub="Connections and requests"
+                        onClick={() => router.push('/my_network')}
+                    />
+                    <SettingsItem
+                        icon={Bell}
+                        label="Notifications"
+                        sub="Requests, likes and comments"
+                        badge={unreadCount}
+                        onClick={() => router.push('/notifications')}
+                    />
+                    <SettingsItem
+                        icon={Search}
+                        label="Explore"
+                        sub="Find people to connect with"
+                        onClick={() => router.push('/search')}
+                    />
+                </div>
+
                 {/* Appearance */}
                 <div className={styles.sectionTitle}>Appearance</div>
                 <div className={`${styles.group} mt-enter`} style={{ animationDelay: '60ms' }}>
@@ -133,27 +167,18 @@ export default function Settings() {
                 {/* Privacy & Support */}
                 <div className={styles.sectionTitle}>Privacy & Support</div>
                 <div className={`${styles.group} mt-enter`} style={{ animationDelay: '120ms' }}>
-                    <div className={styles.item} onClick={() => router.push('/privacy_policy')}>
-                        <div className={styles.iconBox}>
-                            <ShieldCheck className={styles.icon} />
-                        </div>
-                        <div className={styles.labelBlock}>
-                            <span className={styles.label}>Privacy Policy</span>
-                            <span className={styles.sub}>How we handle your data</span>
-                        </div>
-                        <ChevronRight className={styles.arrowIcon} />
-                    </div>
-
-                    <div className={styles.item} onClick={() => { window.location.href = 'mailto:support@mitrata.app'; }}>
-                        <div className={styles.iconBox}>
-                            <CircleHelp className={styles.icon} />
-                        </div>
-                        <div className={styles.labelBlock}>
-                            <span className={styles.label}>Help & Support</span>
-                            <span className={styles.sub}>Get answers or contact us</span>
-                        </div>
-                        <ChevronRight className={styles.arrowIcon} />
-                    </div>
+                    <SettingsItem
+                        icon={ShieldCheck}
+                        label="Privacy Policy"
+                        sub="How we handle your data"
+                        onClick={() => router.push('/privacy_policy')}
+                    />
+                    <SettingsItem
+                        icon={CircleHelp}
+                        label="Help & Support"
+                        sub="FAQs and how to reach us"
+                        onClick={() => router.push('/help_support')}
+                    />
                 </div>
 
                 {/* Account Actions */}


### PR DESCRIPTION
## Summary
- My Network / messaging no longer flash an empty state before data actually loads.
- Settings redesigned with a new Quick Access section (My Network, Notifications, Explore) — My Network had no direct nav path on mobile at all.
- New real Help & Support page (FAQ + contact card) replacing a bare mailto link.
- Privacy Policy redesigned: fixed wrong app name ("SocialMedia"), outdated delete-account copy, modernized CSS to the real design tokens, removed a now-fully-unused dependency.
- Support email standardized to mitrata.llp@gmail.com everywhere.

## Test plan
- [ ] Open My Network / a message thread — confirm a loader shows briefly instead of "No connections/messages yet"
- [ ] Settings → Quick Access → confirm My Network/Notifications/Explore all navigate correctly
- [ ] Settings → Help & Support → confirm FAQ accordion works and email is correct
- [ ] Privacy Policy in both light and dark mode