### PR TITLE
fix: account deletion relocation, password show/hide, responsive auth pages

### DIFF
--- a/frontend/src/Components/ui/PasswordInput.jsx
+++ b/frontend/src/Components/ui/PasswordInput.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+
+/** A password <input> with a show/hide toggle — wraps whatever input
+ * className the page already uses so it drops in as a straight
+ * replacement for a bare <input type="password">. */
+export default function PasswordInput({ className, style, ...inputProps }) {
+  const [visible, setVisible] = useState(false);
+  return (
+    <div style={{ position: 'relative', width: '100%' }}>
+      <input
+        {...inputProps}
+        type={visible ? 'text' : 'password'}
+        className={className}
+        style={{ ...style, paddingRight: 42, boxSizing: 'border-box', width: '100%' }}
+      />
+      <button
+        type="button"
+        onClick={() => setVisible((v) => !v)}
+        aria-label={visible ? 'Hide password' : 'Show password'}
+        style={{
+          position: 'absolute',
+          right: 14,
+          top: '50%',
+          transform: 'translateY(-50%)',
+          background: 'none',
+          border: 'none',
+          padding: 0,
+          cursor: 'pointer',
+          color: 'var(--mt-ink3)',
+          display: 'flex',
+        }}
+      >
+        {visible ? <EyeOff size={17} strokeWidth={1.8} /> : <Eye size={17} strokeWidth={1.8} />}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/layout/userLayout/index.jsx
+++ b/frontend/src/layout/userLayout/index.jsx
@@ -2,8 +2,12 @@ import Navbar from '@/Components/Navbar'
 import React from 'react'
 
 export default function UserLayout({children}) {
+  // The wrapper wasn't a flex container, so `flex: 1` on <main> did nothing —
+  // pages using min-height:100svh inside it (login, forgot-password) got
+  // that on top of Navbar's own height instead of filling the space actually
+  // left over, pushing content down and off the bottom of the screen.
   return (
-    <div>
+    <div style={{ minHeight: '100dvh', display: 'flex', flexDirection: 'column' }}>
         <Navbar/>
         <main style={{ flex: 1, overflowY: 'auto' }}>
             {children}

--- a/frontend/src/pages/forgot-password/index.jsx
+++ b/frontend/src/pages/forgot-password/index.jsx
@@ -6,6 +6,7 @@ import styles from '../login/styles.module.css'
 import { sendOtp, resendOtp, verifyOtp, resetPasswordAction } from '@/config/redux/action/authAction'
 import { useToast } from '@/Components/Toast'
 import Button from '@/Components/ui/Button'
+import PasswordInput from '@/Components/ui/PasswordInput'
 
 const RESEND_COOLDOWN_S = 60;
 
@@ -130,17 +131,15 @@ export default function ForgotPassword() {
                     className={styles.inputField}
                     style={{ textAlign: 'center', fontSize: '1.4rem', letterSpacing: '0.4em' }}
                   />
-                  <input
+                  <PasswordInput
                     value={newPassword}
                     onChange={(e) => setNewPassword(e.target.value)}
-                    type="password"
                     placeholder="New password"
                     className={styles.inputField}
                   />
-                  <input
+                  <PasswordInput
                     value={confirmPassword}
                     onChange={(e) => setConfirmPassword(e.target.value)}
-                    type="password"
                     placeholder="Confirm new password"
                     className={styles.inputField}
                   />

--- a/frontend/src/pages/help_support/delete_account/DeleteAccount.module.css
+++ b/frontend/src/pages/help_support/delete_account/DeleteAccount.module.css
@@ -1,0 +1,146 @@
+.container {
+    max-width: 520px;
+    margin: 0 auto;
+    padding: 24px 20px 100px;
+}
+
+.backBtn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: none;
+    border: none;
+    color: var(--mt-ink2);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    padding: 0;
+    margin-bottom: 20px;
+}
+
+.backIcon {
+    width: 18px;
+    height: 18px;
+}
+
+.iconBadge {
+    width: 56px;
+    height: 56px;
+    border-radius: 16px;
+    background: color-mix(in srgb, var(--mt-danger) 12%, transparent);
+    color: var(--mt-danger);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 16px;
+}
+
+.title {
+    font-family: var(--mt-font-display);
+    font-size: 24px;
+    font-weight: 800;
+    color: var(--mt-ink);
+    margin: 0 0 8px;
+}
+
+.sub {
+    color: var(--mt-ink2);
+    font-size: 13.5px;
+    line-height: 1.6;
+    margin: 0 0 24px;
+}
+
+.list {
+    background: var(--mt-surface);
+    border: 1px solid var(--mt-border);
+    border-radius: 16px;
+    padding: 18px 20px;
+    margin-bottom: 24px;
+    box-shadow: var(--mt-shadow);
+}
+
+.list h3 {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--mt-ink3);
+    margin: 0 0 10px;
+}
+
+.list ul {
+    margin: 0;
+    padding-left: 18px;
+}
+
+.list li {
+    font-size: 13px;
+    color: var(--mt-ink2);
+    line-height: 1.7;
+}
+
+.formCard {
+    background: var(--mt-surface);
+    border: 1px solid var(--mt-border);
+    border-radius: 16px;
+    padding: 20px;
+    box-shadow: var(--mt-shadow);
+}
+
+.modalLabel {
+    display: block;
+    font-size: 12.5px;
+    color: var(--mt-ink2);
+    margin: 0 0 6px;
+}
+
+.modalInput {
+    width: 100%;
+    padding: 11px 14px;
+    border-radius: 10px;
+    border: 1px solid var(--mt-border);
+    background: var(--mt-canvas);
+    color: var(--mt-ink);
+    font-size: 14px;
+    outline: none;
+    box-sizing: border-box;
+    margin-bottom: 16px;
+}
+
+.modalInput:focus {
+    border-color: var(--mt-danger);
+}
+
+.confirmRow {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    margin-bottom: 20px;
+}
+
+.confirmRow input[type="checkbox"] {
+    margin-top: 3px;
+    accent-color: var(--mt-danger);
+}
+
+.confirmRow label {
+    font-size: 13px;
+    color: var(--mt-ink2);
+    line-height: 1.5;
+}
+
+.deleteBtn {
+    width: 100%;
+    padding: 13px;
+    border-radius: 999px;
+    border: none;
+    background: var(--mt-danger);
+    color: #fff;
+    font-weight: 600;
+    font-size: 14px;
+    cursor: pointer;
+}
+
+.deleteBtn:disabled {
+    opacity: 0.5;
+    cursor: default;
+}

--- a/frontend/src/pages/help_support/delete_account/index.jsx
+++ b/frontend/src/pages/help_support/delete_account/index.jsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import { useRouter } from 'next/router';
+import { useSelector, useDispatch } from 'react-redux';
+import DashboardLayout from '@/layout/DashboardLayout';
+import { deleteAccount } from '@/config/redux/action/authAction/index';
+import PasswordInput from '@/Components/ui/PasswordInput';
+import { useToast } from '@/Components/Toast';
+import { ChevronLeft, TriangleAlert } from 'lucide-react';
+import styles from './DeleteAccount.module.css';
+
+const DELETE_CONFIRM_WORD = 'DELETE';
+
+// Moved out of the main Settings page, next to Logout — a permanent,
+// irreversible action sitting one tap away from a routine one (logging out)
+// is exactly the kind of thing a misclick lands on. Reaching this now takes
+// a deliberate trip through Help & Support first, and this page itself adds
+// one more explicit step (the checkbox) before the actual form is usable.
+export default function DeleteAccountPage() {
+    const router = useRouter();
+    const dispatch = useDispatch();
+    const toast = useToast();
+    const { user } = useSelector((state) => state.auth);
+    const [understood, setUnderstood] = useState(false);
+    const [password, setPassword] = useState('');
+    const [confirmText, setConfirmText] = useState('');
+    const [deleting, setDeleting] = useState(false);
+
+    const hasPassword = !user?.userId?.googleId;
+
+    const handleDelete = async () => {
+        if (confirmText !== DELETE_CONFIRM_WORD) return;
+        setDeleting(true);
+        const result = await dispatch(deleteAccount({ password }));
+        setDeleting(false);
+        if (deleteAccount.fulfilled.match(result)) {
+            toast.success('Account permanently deleted');
+            router.push('/login');
+        } else {
+            toast.error(result.payload?.message || 'Failed to delete account');
+        }
+    };
+
+    return (
+        <DashboardLayout>
+            <div className={styles.container}>
+                <button className={styles.backBtn} onClick={() => router.push('/help_support')}>
+                    <ChevronLeft className={styles.backIcon} />
+                    Back to Help & Support
+                </button>
+
+                <div className={styles.iconBadge}>
+                    <TriangleAlert size={26} strokeWidth={1.8} />
+                </div>
+                <h1 className={styles.title}>Delete your account permanently</h1>
+                <p className={styles.sub}>
+                    This is irreversible. Please read what's below carefully before continuing.
+                </p>
+
+                <div className={styles.list}>
+                    <h3>This permanently deletes</h3>
+                    <ul>
+                        <li>Your profile, bio, and photos</li>
+                        <li>All your posts, comments, and reactions</li>
+                        <li>Your messages and conversations</li>
+                        <li>Your connections and pending requests</li>
+                        <li>All uploaded media (images, videos, stories)</li>
+                    </ul>
+                </div>
+
+                <div className={styles.formCard}>
+                    <div className={styles.confirmRow}>
+                        <input
+                            type="checkbox"
+                            id="understand"
+                            checked={understood}
+                            onChange={(e) => setUnderstood(e.target.checked)}
+                        />
+                        <label htmlFor="understand">
+                            I understand this cannot be undone and my data cannot be recovered.
+                        </label>
+                    </div>
+
+                    {understood && (
+                        <>
+                            {hasPassword && (
+                                <>
+                                    <label className={styles.modalLabel}>Enter your password</label>
+                                    <PasswordInput
+                                        value={password}
+                                        onChange={(e) => setPassword(e.target.value)}
+                                        className={styles.modalInput}
+                                    />
+                                </>
+                            )}
+                            <label className={styles.modalLabel}>
+                                Type <strong>{DELETE_CONFIRM_WORD}</strong> to confirm
+                            </label>
+                            <input
+                                type="text"
+                                value={confirmText}
+                                onChange={(e) => setConfirmText(e.target.value)}
+                                className={styles.modalInput}
+                            />
+                            <button
+                                className={styles.deleteBtn}
+                                onClick={handleDelete}
+                                disabled={deleting || confirmText !== DELETE_CONFIRM_WORD || (hasPassword && !password)}
+                            >
+                                {deleting ? 'Deleting…' : 'Delete my account permanently'}
+                            </button>
+                        </>
+                    )}
+                </div>
+            </div>
+        </DashboardLayout>
+    );
+}

--- a/frontend/src/pages/help_support/index.jsx
+++ b/frontend/src/pages/help_support/index.jsx
@@ -4,7 +4,7 @@ import DashboardLayout from '@/layout/DashboardLayout';
 import FaqItem from '@/Components/ui/FaqItem';
 import SettingsItem from '@/Components/ui/SettingsItem';
 import styles from './HelpSupport.module.css';
-import { ChevronLeft, Mail, ShieldCheck } from 'lucide-react';
+import { ChevronLeft, Mail, ShieldCheck, Trash2 } from 'lucide-react';
 
 export const SUPPORT_EMAIL = 'mitrata.llp@gmail.com';
 
@@ -27,7 +27,7 @@ const FAQS = [
   },
   {
     q: 'How do I permanently delete my account?',
-    a: 'Go to Settings → Danger Zone → "Delete my account permanently". This removes your profile, posts, messages, connections and media, and cannot be undone.',
+    a: 'Scroll down to "Delete my account" below. It walks you through exactly what gets removed before asking you to confirm — this is deliberately not a one-click action from Settings, since it can\'t be undone.',
   },
 ];
 
@@ -72,6 +72,18 @@ export default function HelpSupport() {
             label="Privacy Policy"
             sub="How we handle your data"
             onClick={() => router.push('/privacy_policy')}
+          />
+        </div>
+
+        {/* Deliberately down here rather than a quick-access button in
+            Settings — see the comment on that page for why. */}
+        <div className={styles.sectionTitle}>Account</div>
+        <div className={`${styles.group} mt-enter`}>
+          <SettingsItem
+            icon={Trash2}
+            label="Delete my account"
+            sub="Permanent and cannot be undone"
+            onClick={() => router.push('/help_support/delete_account')}
           />
         </div>
       </div>

--- a/frontend/src/pages/login/index.jsx
+++ b/frontend/src/pages/login/index.jsx
@@ -7,6 +7,7 @@ import { loginUser, registerUser, verifyOtp, resendOtp, switchAccountAction, get
 import { emptyMessage } from '@/config/redux/reducer/authReducer'
 import { getSavedAccounts } from '@/config/savedAccounts'
 import Button from '@/Components/ui/Button'
+import PasswordInput from '@/Components/ui/PasswordInput'
 import GoogleLoginButton from '@/Components/ui/GoogleLoginButton'
 import PageLoader from '@/Components/ui/PageLoader'
 
@@ -298,7 +299,12 @@ function LoginComponent() {
                 </div>
               )}
               <input value={email} onChange={(e) => setEmail(e.target.value)} type="text" placeholder="Email" className={styles.inputField} />
-              <input onChange={(e) => setPassword(e.target.value)} type="password" placeholder="Password" className={styles.inputField} />
+              <PasswordInput
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Password"
+                className={styles.inputField}
+              />
 
               {userLoginMethod && (
                 <div style={{ textAlign: 'right', marginTop: '2px' }}>

--- a/frontend/src/pages/login/styles.module.css
+++ b/frontend/src/pages/login/styles.module.css
@@ -1,5 +1,8 @@
 .container {
-    min-height: 100svh;
+    /* Fills whatever height <main> actually has left after Navbar (now that
+       UserLayout is a real flex column) instead of a full extra 100svh
+       stacked on top of it. */
+    min-height: 100%;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -214,7 +217,11 @@
 
 @media (max-width: 860px) {
     .cardContainer {
-        flex-direction: column-reverse;
+        /* Was column-reverse — the decorative "Remembered it? / Back to
+           sign in" panel rendered ABOVE the actual email/password form on
+           mobile, so the first thing anyone saw was a link to leave the
+           flow rather than the input they came here to use. */
+        flex-direction: column;
         width: 100%;
         min-height: 0;
     }

--- a/frontend/src/pages/settings/index.jsx
+++ b/frontend/src/pages/settings/index.jsx
@@ -2,8 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useSelector, useDispatch } from 'react-redux';
 import styles from './Settings.module.css';
-import { logout, deleteAccount } from '@/config/redux/action/authAction/index';
-import { useToast } from '@/Components/Toast';
+import { logout } from '@/config/redux/action/authAction/index';
 import {
     ChevronRight,
     Moon,
@@ -12,28 +11,19 @@ import {
     ShieldCheck,
     CircleHelp,
     LogOut,
-    Trash2,
     UsersRound,
     Bell,
-    Search,
 } from 'lucide-react';
 import DashboardLayout from '@/layout/DashboardLayout';
 import SettingsItem from '@/Components/ui/SettingsItem';
 import { useNotification } from '@/Components/NotificationProvider';
 
-const DELETE_CONFIRM_WORD = 'DELETE';
-
 export default function Settings() {
     const router = useRouter();
     const dispatch = useDispatch();
-    const toast = useToast();
     const { user } = useSelector(state => state.auth);
     const { unreadCount } = useNotification();
     const [theme, setTheme] = useState('system'); // light, dark, system
-    const [showDeleteModal, setShowDeleteModal] = useState(false);
-    const [deletePassword, setDeletePassword] = useState('');
-    const [deleteConfirmText, setDeleteConfirmText] = useState('');
-    const [deleting, setDeleting] = useState(false);
 
     useEffect(() => {
         const savedTheme = localStorage.getItem('theme') || 'system';
@@ -54,21 +44,6 @@ export default function Settings() {
         if (window.confirm("Are you sure you want to log out?")) {
             dispatch(logout());
             router.push('/login');
-        }
-    };
-
-    const hasPassword = !user?.userId?.googleId;
-
-    const handleDeleteAccount = async () => {
-        if (deleteConfirmText !== DELETE_CONFIRM_WORD) return;
-        setDeleting(true);
-        const result = await dispatch(deleteAccount({ password: deletePassword }));
-        setDeleting(false);
-        if (deleteAccount.fulfilled.match(result)) {
-            toast.success('Account permanently deleted');
-            router.push('/login');
-        } else {
-            toast.error(result.payload?.message || 'Failed to delete account');
         }
     };
 
@@ -118,12 +93,6 @@ export default function Settings() {
                         sub="Requests, likes and comments"
                         badge={unreadCount}
                         onClick={() => router.push('/notifications')}
-                    />
-                    <SettingsItem
-                        icon={Search}
-                        label="Explore"
-                        sub="Find people to connect with"
-                        onClick={() => router.push('/search')}
                     />
                 </div>
 
@@ -189,66 +158,12 @@ export default function Settings() {
                     </button>
                 </div>
 
-                {/* Danger Zone */}
-                <div className={styles.sectionTitle}>Danger Zone</div>
-                <div className={`${styles.group} mt-enter`} style={{ animationDelay: '220ms' }}>
-                    <button
-                        className={`${styles.logoutBtn} mt-btn-lift`}
-                        onClick={() => setShowDeleteModal(true)}
-                    >
-                        <Trash2 className={styles.logoutIcon} />
-                        Delete my account permanently
-                    </button>
-                </div>
-
-                {showDeleteModal && (
-                    <div className={styles.modalOverlay} onClick={() => !deleting && setShowDeleteModal(false)}>
-                        <div className={styles.modalBox} onClick={(e) => e.stopPropagation()}>
-                            <h3 className={styles.modalTitle}>Delete account permanently</h3>
-                            <p className={styles.modalSub}>
-                                This deletes your profile, posts, messages, connections and media forever.
-                                This can't be undone.
-                            </p>
-
-                            {hasPassword && (
-                                <input
-                                    type="password"
-                                    placeholder="Enter your password"
-                                    value={deletePassword}
-                                    onChange={(e) => setDeletePassword(e.target.value)}
-                                    className={styles.modalInput}
-                                />
-                            )}
-
-                            <label className={styles.modalLabel}>
-                                Type <strong>{DELETE_CONFIRM_WORD}</strong> to confirm
-                            </label>
-                            <input
-                                type="text"
-                                value={deleteConfirmText}
-                                onChange={(e) => setDeleteConfirmText(e.target.value)}
-                                className={styles.modalInput}
-                            />
-
-                            <div className={styles.modalActions}>
-                                <button
-                                    className={styles.modalCancelBtn}
-                                    onClick={() => setShowDeleteModal(false)}
-                                    disabled={deleting}
-                                >
-                                    Cancel
-                                </button>
-                                <button
-                                    className={styles.modalDeleteBtn}
-                                    onClick={handleDeleteAccount}
-                                    disabled={deleting || deleteConfirmText !== DELETE_CONFIRM_WORD || (hasPassword && !deletePassword)}
-                                >
-                                    {deleting ? 'Deleting…' : 'Delete permanently'}
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                )}
+                {/* Deleting an account permanently is intentionally NOT a
+                    direct action on this page anymore — it used to be a
+                    button styled identically to (and sitting right next to)
+                    Log out, which is exactly the kind of thing a misclick
+                    lands on. It's reachable only through Help & Support's
+                    guide now, adding real deliberate steps in between. */}
 
                 <div className={styles.footer}>
                     <p>Mitrata App v1.2.0</p>


### PR DESCRIPTION
## Summary
- Removed Explore from Settings Quick Access (already has its own nav slot).
- Moved account deletion out of Settings (was next to Logout, a misclick risk) into a guided Help & Support flow with an extra confirmation step.
- Added password show/hide toggle everywhere passwords are entered.
- Fixed real responsive bugs on login/forgot-password: UserLayout wasn't a real flex container (main's flex:1 did nothing), causing huge empty gaps and content pushed off-screen on mobile; mobile card order had the decorative panel above the actual form.

## Test plan
- [ ] Settings no longer shows Explore or a delete-account button
- [ ] Help & Support → Delete my account → confirm the checkbox gate + full flow works
- [ ] Login/forgot-password on mobile width: no empty gap, form appears before the decorative panel
- [ ] Password fields show/hide correctly via the eye icon