### PR TITLE
fix: duplicate connection-accepted notifications

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -664,12 +664,20 @@ export const acceptConnectionRequest = async (req, res) => {
             });
         }
 
+        // Was unconditional — a double-click, a client retry after a slow
+        // response, or the request simply being actioned twice re-created a
+        // fresh Notification and re-emitted 'connectionAccepted' every
+        // single time, regardless of whether anything actually changed.
+        // That's the literal cause of "notification accepted, showing
+        // multiple times" — only a genuine pending -> decided transition
+        // should ever notify.
+        const wasPending = connection.status_accepted === null;
+
         connection.status_accepted = (action_type === 'accept');
         await connection.save();
 
-        // If accepted, notify the sender
-        if (action_type === 'accept') {
-            const senderUser = await User.findById(connection.userId);
+        // If accepted, notify the sender — only on the actual transition
+        if (wasPending && action_type === 'accept') {
             await Notification.create({
                 userId: connection.userId,
                 type: 'connection_accepted',

--- a/frontend/src/pages/my_network/index.jsx
+++ b/frontend/src/pages/my_network/index.jsx
@@ -25,6 +25,11 @@ export default function MyNetwork() {
     // tab showed its "No connections/requests yet" empty state for a beat
     // before the real data replaced it. This tracks the actual fetch.
     const [dataLoaded, setDataLoaded] = useState(false);
+    // Guards against a double-click firing acceptConnectionRequest twice for
+    // the same request before the first response comes back — paired with
+    // the backend's own idempotency check, but disabling the buttons is what
+    // stops a second request from ever being sent in the first place.
+    const [processingRequestId, setProcessingRequestId] = useState(null);
     const toast = useToast();
     const { callUser } = useCall();
 
@@ -83,6 +88,8 @@ export default function MyNetwork() {
     }, [authState.connection, authState.connectionRequest]);
 
     const handleAction = async (requestId, action) => {
+        if (processingRequestId) return;
+        setProcessingRequestId(requestId);
         try {
             await dispatch(acceptConnectionRequest({
                 connectionId: requestId,
@@ -93,6 +100,8 @@ export default function MyNetwork() {
         } catch (error) {
             console.error("Failed to update connection:", error);
             toast.error(error.message || "Failed to update connection");
+        } finally {
+            setProcessingRequestId(null);
         }
     };
 
@@ -196,6 +205,7 @@ export default function MyNetwork() {
                                                 <button
                                                     className={`${styles.acceptBtn} mt-btn-lift`}
                                                     onClick={() => handleAction(req._id, 'accept')}
+                                                    disabled={processingRequestId === req._id}
                                                     title="Accept"
                                                 >
                                                     <Check size={15} strokeWidth={2} /> Accept
@@ -203,6 +213,7 @@ export default function MyNetwork() {
                                                 <button
                                                     className={`${styles.ignoreBtn} mt-btn-lift`}
                                                     onClick={() => handleAction(req._id, 'reject')}
+                                                    disabled={processingRequestId === req._id}
                                                     title="Ignore"
                                                 >
                                                     <X size={15} strokeWidth={2} /> Ignore


### PR DESCRIPTION
acceptConnectionRequest had no idempotency check, so any repeated call (double-click, retry) re-created the notification and re-emitted the socket event. Fixed with a pending->decided transition check server-side, plus a frontend double-click guard.