### PR TITLE
fix: remaining blank/empty-flash loading gaps

### DIFF
--- a/frontend/src/Components/NotificationProvider/index.jsx
+++ b/frontend/src/Components/NotificationProvider/index.jsx
@@ -32,6 +32,11 @@ export function NotificationProvider({ children }) {
     const [notifications, setNotifications] = useState([]);
     const [unreadCount, setUnreadCount] = useState(0);
     const [recentNotifs, setRecentNotifs] = useState([]);
+    // recentNotifs.length === 0 reads identically whether nothing has loaded
+    // yet or there's genuinely nothing there — the notifications page was
+    // showing "No notifications yet" for a beat before the real fetch below
+    // resolved, every single time.
+    const [notificationsLoaded, setNotificationsLoaded] = useState(false);
     const [onlineUsers, setOnlineUsers] = useState(new Set());
     const [socketInstance, setSocketInstance] = useState(null);
     const socketRef = useRef(null);
@@ -97,7 +102,10 @@ export function NotificationProvider({ children }) {
     useEffect(() => {
         const fetchNotifications = async () => {
             const token = localStorage.getItem('token');
-            if (!token) return;
+            if (!token) {
+                setNotificationsLoaded(true);
+                return;
+            }
             try {
                 const res = await axios.get(`${Base_Url}/api/notification/all`, {
                     headers: { Authorization: `Bearer ${token}` }
@@ -121,7 +129,10 @@ export function NotificationProvider({ children }) {
                     metadata: n.metadata || {}
                 })));
                 setUnreadCount(count);
-            } catch { }
+            } catch {
+            } finally {
+                setNotificationsLoaded(true);
+            }
         };
         fetchNotifications();
     }, [authState.loggedIn]);
@@ -306,7 +317,7 @@ export function NotificationProvider({ children }) {
     };
 
     return (
-        <NotificationContext.Provider value={{ showNotification, unreadCount, clearUnread, recentNotifs, socket: socketRef, socketInstance, onlineUsers }}>
+        <NotificationContext.Provider value={{ showNotification, unreadCount, clearUnread, recentNotifs, notificationsLoaded, socket: socketRef, socketInstance, onlineUsers }}>
             {children}
 
             {/* Floating notification popups */}

--- a/frontend/src/config/redux/reducer/postReducer/index.js
+++ b/frontend/src/config/redux/reducer/postReducer/index.js
@@ -10,6 +10,7 @@ const initialState = {
     userPosts: [],
     userPostsHasMore: false,
     userPostsPage: 1,
+    userPostsLoaded: false,
     isError: false,
     postFetched: false,
     isLoading: false,
@@ -128,11 +129,27 @@ const postSlice = createSlice({
             .addCase(getBookmarkedPosts.fulfilled, (state, action) => {
                 state.bookmarkedPosts = action.payload.posts || []
             })
+            .addCase(getPostsByUsername.pending, (state, action) => {
+                // Not on page>1 (load-more) — only the first page of a fresh
+                // username should show the loader again, so navigating
+                // between two different users' activity pages doesn't
+                // briefly show the PREVIOUS user's now-stale posts as if
+                // they were the new user's.
+                if (!action.meta.arg?.page || action.meta.arg.page === 1) {
+                    state.userPostsLoaded = false;
+                }
+            })
             .addCase(getPostsByUsername.fulfilled, (state, action) => {
                 const { posts, hasMore, page } = action.payload;
                 state.userPosts = page > 1 ? [...state.userPosts, ...(posts || [])] : (posts || []);
                 state.userPostsHasMore = !!hasMore;
                 state.userPostsPage = page || 1;
+                state.userPostsLoaded = true;
+            })
+            .addCase(getPostsByUsername.rejected, (state) => {
+                // Still "loaded" (just empty) — otherwise a failed fetch
+                // leaves the page stuck on its loading spinner forever.
+                state.userPostsLoaded = true;
             })
     }
 })

--- a/frontend/src/pages/activity/[username].jsx
+++ b/frontend/src/pages/activity/[username].jsx
@@ -5,6 +5,8 @@ import styles from './index.module.css';
 import DashboardLayout from '@/layout/DashboardLayout';
 import ReportMenu from '@/Components/ReportMenu';
 import EmptyState from '@/Components/ui/EmptyState';
+import PageLoader from '@/Components/ui/PageLoader';
+import BlastLoader from '@/Components/ui/BlastLoader';
 import { getPostsByUsername, deletePost, reactToPost, getAllComments, commentPost, toggleBookmark } from '@/config/redux/action/postAction';
 import { resetPostId } from '@/config/redux/reducer/postReducer';
 import { Base_Url } from '@/config';
@@ -126,7 +128,11 @@ export default function UserActivityPage() {
                 <p className={styles.postCount}>{userPosts.length} post{userPosts.length === 1 ? '' : 's'}</p>
             </div>
 
-            {userPosts.length === 0 ? (
+            {!postState.userPostsLoaded ? (
+                <div className="w-full flex items-center justify-center py-16">
+                    <BlastLoader size={48} />
+                </div>
+            ) : userPosts.length === 0 ? (
                 <EmptyState
                     icon={FileText}
                     title="No posts yet"
@@ -270,6 +276,6 @@ export default function UserActivityPage() {
         </div>
     );
 
-    if (!mounted) return null;
+    if (!mounted) return <PageLoader />;
     return <DashboardLayout>{ActivityContent}</DashboardLayout>;
 }

--- a/frontend/src/pages/notifications/index.jsx
+++ b/frontend/src/pages/notifications/index.jsx
@@ -6,6 +6,7 @@ import { useNotification } from "@/Components/NotificationProvider";
 import { useToast } from "@/Components/Toast";
 import { acceptConnectionRequest } from "@/config/redux/action/authAction";
 import EmptyState from "@/Components/ui/EmptyState";
+import BlastLoader from "@/Components/ui/BlastLoader";
 import Button from "@/Components/ui/Button";
 import {
   CheckCheck,
@@ -132,7 +133,7 @@ function Row({ n, onClick }) {
 
 export default function Notifications() {
   const router = useRouter();
-  const { recentNotifs, clearUnread } = useNotification();
+  const { recentNotifs, clearUnread, notificationsLoaded } = useNotification();
 
   const { today, earlier } = useMemo(() => {
     const startOfToday = new Date();
@@ -177,7 +178,11 @@ export default function Notifications() {
           </div>
 
           <div className="rounded-[22px] border border-[var(--mt-border)] bg-[var(--mt-surface)] shadow-[var(--mt-shadow)] overflow-hidden">
-            {recentNotifs.length === 0 ? (
+            {!notificationsLoaded ? (
+              <div className="w-full flex items-center justify-center py-16">
+                <BlastLoader size={48} />
+              </div>
+            ) : recentNotifs.length === 0 ? (
               <EmptyState
                 icon={Bell}
                 title="No notifications yet"

--- a/frontend/src/pages/profile/index.jsx
+++ b/frontend/src/pages/profile/index.jsx
@@ -9,6 +9,8 @@ import DashboardLayout from '@/layout/DashboardLayout' // Added for Tablet/Mobil
 import Skeleton from '@/Components/ui/Skeleton'
 import { Camera, Pencil, ArrowRight, Plus, X, Heart, Bookmark } from 'lucide-react'
 import EmptyState from '@/Components/ui/EmptyState'
+import PageLoader from '@/Components/ui/PageLoader'
+import BlastLoader from '@/Components/ui/BlastLoader'
 import { useToast } from '@/Components/Toast'
 import { compressImage, resizeToExactSize } from '@/utils/imageProcessing'
 
@@ -407,7 +409,11 @@ export default function Profile() {
             </div>
 
             {contentTab === 'posts' && (
-              userPosts.length > 0 ? (
+              !postState.userPostsLoaded ? (
+                <div className="w-full flex items-center justify-center py-12">
+                  <BlastLoader size={40} />
+                </div>
+              ) : userPosts.length > 0 ? (
                 <div className={styles.textPostList}>
                   {userPosts.map((post) => (
                     <div key={post._id} className={styles.textPostCard}>
@@ -641,7 +647,7 @@ export default function Profile() {
   );
 
   // FIXED: Replaced standard return with null if not mounted to solve SSR hydration errors
-  if (!mounted) return null;
+  if (!mounted) return <PageLoader />;
 
   return <DashboardLayout>{MainContent}</DashboardLayout>;
 }

--- a/frontend/src/pages/view_profile/[username].jsx
+++ b/frontend/src/pages/view_profile/[username].jsx
@@ -9,6 +9,7 @@ import { downloadResume, getConnectionRequest, sendConnectionRequest } from '@/c
 import serverAxios from '@/config/serverAxios'
 import { UserPlus, Check, Download, ArrowRight } from 'lucide-react'
 import ReportMenu from '@/Components/ReportMenu'
+import BlastLoader from '@/Components/ui/BlastLoader'
 
 export default function viewProfilePage({ userProfile }) {
     const router = useRouter()
@@ -219,7 +220,11 @@ export default function viewProfilePage({ userProfile }) {
                 <div className={styles.userActivitySidebar}>
                     <h3>Recent Activity</h3>
 
-                    {userPost.length > 0 ? (
+                    {!postState.userPostsLoaded ? (
+                        <div className="w-full flex items-center justify-center py-8">
+                            <BlastLoader size={36} />
+                        </div>
+                    ) : userPost.length > 0 ? (
                         <>
                             {recentPosts.map((post) => (
                                 <div key={post._id} className={styles.sidebarPostCard}>


### PR DESCRIPTION
Notifications had no loading signal at all; profile and activity still had blank return-null flashes from before; getPostsByUsername had no loaded flag so profile/activity/view_profile's post lists all showed empty states prematurely too.