### PR TITLE
Private accounts, blocking, push preference, and Settings redesign

### DIFF
--- a/backend/controllers/post.controller.js
+++ b/backend/controllers/post.controller.js
@@ -220,9 +220,29 @@ export const getPostsByUsername = async (req, res) => {
     const limit = parseInt(req.query.limit) || 20;
     const skip = (page - 1) * limit;
 
-    const author = await User.findOne({ username }).select("_id").lean();
+    const author = await User.findOne({ username }).select("_id isPrivate blockedUsers").lean();
     if (!author) {
       return res.status(404).json({ message: "User not found" });
+    }
+
+    const isSelf = requesterId && requesterId.toString() === author._id.toString();
+    if (author.blockedUsers?.some((id) => id.toString() === requesterId?.toString())) {
+      return res.status(404).json({ message: "User not found" });
+    }
+    if (author.isPrivate && !isSelf) {
+      // Same gate as getAllUserBasedOnUsername — a private account's posts
+      // shouldn't be fetchable directly even if the profile card itself is
+      // locked, since this is a separate endpoint the activity page hits.
+      const isConnection = await ConnectionRequest.exists({
+        status_accepted: true,
+        $or: [
+          { userId: requesterId, connectionId: author._id },
+          { userId: author._id, connectionId: requesterId }
+        ]
+      });
+      if (!isConnection) {
+        return res.status(200).json({ posts: [], hasMore: false, totalPosts: 0, page: 1, limit });
+      }
     }
 
     const query = { userId: author._id };

--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -423,6 +423,90 @@ export const updateUserProfile = async (req, res) => {
     }
 }
 
+// User-model account fields (username, privacy, push preference) — kept
+// separate from updateUserProfile above, which only ever touched the
+// Profile document's fields.
+export const updateAccountSettings = async (req, res) => {
+    try {
+        const { username, isPrivate, pushEnabled } = req.body;
+        const user = await User.findById(req.userId);
+        if (!user) return res.status(404).json({ message: "User not found" });
+
+        if (username !== undefined && username !== user.username) {
+            const usernameRegex = /^[a-zA-Z0-9_]{3,30}$/;
+            if (!usernameRegex.test(username)) {
+                return res.status(400).json({ message: "Username must be 3-30 characters, alphanumeric and underscores only" });
+            }
+            const taken = await User.findOne({ username, _id: { $ne: user._id } });
+            if (taken) return res.status(400).json({ message: "Username already taken" });
+            user.username = username;
+        }
+
+        if (isPrivate !== undefined) user.isPrivate = !!isPrivate;
+        if (pushEnabled !== undefined) user.pushEnabled = !!pushEnabled;
+
+        await user.save();
+        return res.json({ message: "Updated successfully!", isPrivate: user.isPrivate, pushEnabled: user.pushEnabled, username: user.username });
+    } catch (error) {
+        if (error.code === 11000) {
+            return res.status(400).json({ message: "Username already taken" });
+        }
+        return res.status(500).json({ message: error.message });
+    }
+};
+
+// Blocking someone removes any existing connection between you (so it
+// disappears from both My Network lists) and prevents new connection
+// requests/messages either direction, in addition to hiding a private
+// account's content — see the isPrivate gate in getUserAndProfile.
+export const blockUser = async (req, res) => {
+    try {
+        const { targetId } = req.body;
+        if (!targetId || !mongoose.Types.ObjectId.isValid(targetId)) {
+            return res.status(400).json({ message: "A valid targetId is required" });
+        }
+        if (targetId === req.userId.toString()) {
+            return res.status(400).json({ message: "You can't block yourself" });
+        }
+
+        await User.updateOne({ _id: req.userId }, { $addToSet: { blockedUsers: targetId } });
+        await ConnectionRequest.deleteMany({
+            $or: [
+                { userId: req.userId, connectionId: targetId },
+                { userId: targetId, connectionId: req.userId }
+            ]
+        });
+
+        return res.json({ message: "User blocked" });
+    } catch (error) {
+        return res.status(500).json({ message: error.message });
+    }
+};
+
+export const unblockUser = async (req, res) => {
+    try {
+        const { targetId } = req.body;
+        if (!targetId || !mongoose.Types.ObjectId.isValid(targetId)) {
+            return res.status(400).json({ message: "A valid targetId is required" });
+        }
+        await User.updateOne({ _id: req.userId }, { $pull: { blockedUsers: targetId } });
+        return res.json({ message: "User unblocked" });
+    } catch (error) {
+        return res.status(500).json({ message: error.message });
+    }
+};
+
+export const getBlockedUsers = async (req, res) => {
+    try {
+        const user = await User.findById(req.userId)
+            .populate('blockedUsers', 'name username profilePicture')
+            .select('blockedUsers');
+        return res.json({ blockedUsers: user?.blockedUsers || [] });
+    } catch (error) {
+        return res.status(500).json({ message: error.message });
+    }
+};
+
 
 
 export const getUserAndProfile = async (req, res) => {
@@ -431,7 +515,7 @@ export const getUserAndProfile = async (req, res) => {
         // req.userId is already a verified-to-exist user (see verifyToken) —
         // no need to re-fetch the User doc just to read its own id back.
         const userProfile = await Profile.findOne({ userId: req.userId })
-            .populate("userId", "name email username profilePicture coverPhoto createAt role googleId");
+            .populate("userId", "name email username profilePicture coverPhoto createAt role googleId isPrivate pushEnabled");
 
         if (!userProfile) {
             return res.status(404).json({ message: "profile not found" });
@@ -518,6 +602,12 @@ export const sendconnectionrequest = async (req, res) => {
         // Prevent sending request to yourself
         if (user._id.toString() === connectionUser._id.toString()) {
             return res.status(400).json({ message: "Cannot send request to yourself" });
+        }
+
+        const blocked = user.blockedUsers?.some((id) => id.toString() === connectionUser._id.toString())
+            || connectionUser.blockedUsers?.some((id) => id.toString() === user._id.toString());
+        if (blocked) {
+            return res.status(403).json({ message: "Unable to connect with this user" });
         }
 
         // Check if request already exists IN EITHER DIRECTION
@@ -723,9 +813,45 @@ export const acceptConnectionRequest = async (req, res) => {
 export const getAllUserBasedOnUsername = async (req, res) => {
     const { username } = req.query
     try {
-        const users = await User.findOne({ username })
-        if (!users) return res.status(404).json({ message: 'user not found' })
-        const userProfile = await Profile.findOne({ userId: users._id })
+        const targetUser = await User.findOne({ username })
+        if (!targetUser) return res.status(404).json({ message: 'user not found' })
+
+        const viewerId = req.userId;
+        const isSelf = viewerId && viewerId.toString() === targetUser._id.toString();
+
+        if (targetUser.blockedUsers?.some((id) => id.toString() === viewerId?.toString())) {
+            return res.status(404).json({ message: 'user not found' });
+        }
+
+        // Private account: only accepted connections (and the owner) see
+        // the real profile — everyone else gets a limited card, same as
+        // Instagram/X. Search/discovery is unaffected by this.
+        let isConnection = isSelf;
+        if (!isSelf && targetUser.isPrivate) {
+            isConnection = !!(await ConnectionRequest.exists({
+                status_accepted: true,
+                $or: [
+                    { userId: viewerId, connectionId: targetUser._id },
+                    { userId: targetUser._id, connectionId: viewerId }
+                ]
+            }));
+        }
+
+        if (targetUser.isPrivate && !isSelf && !isConnection) {
+            return res.json({
+                profile: {
+                    userId: {
+                        _id: targetUser._id,
+                        name: targetUser.name,
+                        username: targetUser.username,
+                        profilePicture: targetUser.profilePicture
+                    },
+                    isPrivateLocked: true
+                }
+            });
+        }
+
+        const userProfile = await Profile.findOne({ userId: targetUser._id })
             .populate('userId', 'name username email profilePicture coverPhoto');
         return res.json({ "profile": userProfile })
     } catch (error) {

--- a/backend/models/users.model.js
+++ b/backend/models/users.model.js
@@ -60,6 +60,22 @@ const userSchema = new mongoose.Schema({
         type: [String],
         default: []
     },
+    // Private account: profile/posts are only visible to accepted
+    // connections; everyone else sees a limited "this account is private"
+    // card. Doesn't affect search visibility (same as Instagram/X — you can
+    // still find a private account, just not see into it uninvited).
+    isPrivate: {
+        type: Boolean,
+        default: false
+    },
+    blockedUsers: [{
+        type: mongoose.Schema.Types.ObjectId,
+        ref: "user"
+    }],
+    pushEnabled: {
+        type: Boolean,
+        default: true
+    },
 }, {
     timestamps: true
 })

--- a/backend/routes/user.routes.js
+++ b/backend/routes/user.routes.js
@@ -1,6 +1,6 @@
 
 import multer from "multer";
-import { acceptConnectionRequest, downloadProfile, findSearchUser, getAllUserBasedOnUsername, getMyConnectionRequest, getUserAndProfile, login, logout, register, sendconnectionrequest, updateProfileData, updateUserProfile, uploadCoverPhoto, uploadImage, uploadProfilePicture, whatAreMyConnection, searchUsers, getSuggestions, googleLogin, googleLoginCallback, refreshAccessToken, deleteMyAccount, switchAccount, registerFcmToken, unregisterFcmToken } from "../controllers/user.controller.js";
+import { acceptConnectionRequest, downloadProfile, findSearchUser, getAllUserBasedOnUsername, getMyConnectionRequest, getUserAndProfile, login, logout, register, sendconnectionrequest, updateProfileData, updateUserProfile, updateAccountSettings, uploadCoverPhoto, uploadImage, uploadProfilePicture, whatAreMyConnection, searchUsers, getSuggestions, googleLogin, googleLoginCallback, refreshAccessToken, deleteMyAccount, switchAccount, registerFcmToken, unregisterFcmToken, blockUser, unblockUser, getBlockedUsers } from "../controllers/user.controller.js";
 import { sendOtp, verifyOtp, resendOtp, resetPassword } from "../controllers/otp.controller.js";
 import { createReport } from "../controllers/admin.controller.js";
 import { Router } from "express"
@@ -38,6 +38,10 @@ router.route('/user/update_profile_picture').post(verifyToken, upload.single('pr
 router.route('/user/update_cover_photo').post(verifyToken, upload.single('coverPhoto'), uploadCoverPhoto);
 router.route('/upload/image').post(verifyToken, upload.single('image'), uploadImage);
 router.route('/user/setting/user_update').post(verifyToken, updateUserProfile);
+router.route('/user/setting/account_update').post(verifyToken, updateAccountSettings);
+router.route('/user/block').post(verifyToken, blockUser);
+router.route('/user/unblock').post(verifyToken, unblockUser);
+router.route('/user/blocked').get(verifyToken, getBlockedUsers);
 router.route('/get_user_and_profile').get(verifyToken, getUserAndProfile);
 router.route('/update_profile').post(verifyToken, updateProfileData);
 router.route('/user/findinguser').get(verifyToken, findSearchUser);
@@ -54,7 +58,10 @@ router.route('/user/is_accepted_connection_request').post(verifyToken, acceptCon
 router.route('/user/search').get(searchUsers);
 router.route('/user/suggestions').get(verifyToken, getSuggestions);
 
-router.route('/user/get_user_based_on_username').get(getAllUserBasedOnUsername);
+// Needs to know WHO's asking to gate private accounts correctly (see
+// getAllUserBasedOnUsername) — view_profile is only ever reached from
+// within the authenticated app shell anyway, same as everything else here.
+router.route('/user/get_user_based_on_username').get(verifyToken, getAllUserBasedOnUsername);
 
 // Messaging routes (all protected)
 router.route('/user/send_message').post(

--- a/backend/utils/push.js
+++ b/backend/utils/push.js
@@ -8,7 +8,8 @@ import User from "../models/users.model.js";
 export const sendPush = async (userId, { title, body, data = {} }) => {
     if (!messaging) return; // not configured — same no-op pattern as sendMail
 
-    const user = await User.findById(userId).select("fcmTokens").lean();
+    const user = await User.findById(userId).select("fcmTokens pushEnabled").lean();
+    if (user?.pushEnabled === false) return; // user turned push off in Settings
     const tokens = user?.fcmTokens || [];
     if (tokens.length === 0) return;
 

--- a/frontend/src/Components/ui/Toggle.jsx
+++ b/frontend/src/Components/ui/Toggle.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import styles from './Toggle.module.css';
+
+/** A simple on/off switch — shared by every Settings-style boolean
+ * preference (private account, push notifications, ...) instead of each
+ * page hand-rolling its own checkbox styling. */
+export default function Toggle({ checked, onChange, disabled }) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      disabled={disabled}
+      className={`${styles.toggle} ${checked ? styles.on : ''}`}
+      onClick={() => onChange(!checked)}
+    >
+      <span className={styles.knob} />
+    </button>
+  );
+}

--- a/frontend/src/Components/ui/Toggle.module.css
+++ b/frontend/src/Components/ui/Toggle.module.css
@@ -1,0 +1,37 @@
+.toggle {
+    position: relative;
+    width: 44px;
+    height: 26px;
+    border-radius: 999px;
+    border: none;
+    background: var(--mt-border);
+    cursor: pointer;
+    flex-shrink: 0;
+    transition: background 0.2s var(--mt-ease);
+    padding: 0;
+}
+
+.toggle.on {
+    background: var(--mt-grad);
+}
+
+.toggle:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
+.knob {
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: #fff;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.25);
+    transition: transform 0.2s var(--mt-ease);
+}
+
+.toggle.on .knob {
+    transform: translateX(18px);
+}

--- a/frontend/src/config/redux/action/authAction/index.js
+++ b/frontend/src/config/redux/action/authAction/index.js
@@ -210,6 +210,56 @@ export const updateUserProfile = createAsyncThunk(
     }
 )
 
+// Username/privacy/push-preference — User-model fields, separate from
+// updateUserProfile above which only ever touches the Profile document.
+export const updateAccountSettings = createAsyncThunk(
+    "user/updateAccountSettings",
+    async (payload, thunkApi) => {
+        try {
+            const response = await clientServer.post('/user/setting/account_update', payload);
+            return thunkApi.fulfillWithValue(response.data);
+        } catch (error) {
+            return thunkApi.rejectWithValue(error.response?.data || { message: "Update failed" });
+        }
+    }
+);
+
+export const blockUser = createAsyncThunk(
+    "user/blockUser",
+    async (targetId, thunkApi) => {
+        try {
+            const response = await clientServer.post('/user/block', { targetId });
+            return thunkApi.fulfillWithValue({ targetId, ...response.data });
+        } catch (error) {
+            return thunkApi.rejectWithValue(error.response?.data || { message: "Failed to block user" });
+        }
+    }
+);
+
+export const unblockUser = createAsyncThunk(
+    "user/unblockUser",
+    async (targetId, thunkApi) => {
+        try {
+            const response = await clientServer.post('/user/unblock', { targetId });
+            return thunkApi.fulfillWithValue({ targetId, ...response.data });
+        } catch (error) {
+            return thunkApi.rejectWithValue(error.response?.data || { message: "Failed to unblock user" });
+        }
+    }
+);
+
+export const getBlockedUsers = createAsyncThunk(
+    "user/getBlockedUsers",
+    async (_arg, thunkApi) => {
+        try {
+            const response = await clientServer.get('/user/blocked');
+            return thunkApi.fulfillWithValue(response.data);
+        } catch (error) {
+            return thunkApi.rejectWithValue(error.response?.data || { message: "Failed to load blocked accounts" });
+        }
+    }
+);
+
 
 
 export const getAllUser = createAsyncThunk(

--- a/frontend/src/config/redux/reducer/authReducer/index.js
+++ b/frontend/src/config/redux/reducer/authReducer/index.js
@@ -1,5 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { getAboutUser, loginUser, registerUser, getAllUser, getConnectionRequest, getMyConnectionRequests, acceptConnectionRequest, downloadResume, updateUserProfile, logout, verifyOtp, resendOtp, sendOtp, resetPasswordAction, deleteAccount, switchAccountAction } from "../../action/authAction/index";
+import { getAboutUser, loginUser, registerUser, getAllUser, getConnectionRequest, getMyConnectionRequests, acceptConnectionRequest, downloadResume, updateUserProfile, updateAccountSettings, blockUser, unblockUser, getBlockedUsers, logout, verifyOtp, resendOtp, sendOtp, resetPasswordAction, deleteAccount, switchAccountAction } from "../../action/authAction/index";
 import { rememberAccount } from "../../../savedAccounts";
 
 
@@ -16,7 +16,8 @@ const initialState = {
     connection: [],
     all_user: [],
     connectionRequest: [],
-    all_profile_fetched: false
+    all_profile_fetched: false,
+    blockedUsers: []
 }
 
 const authSlice = createSlice({
@@ -170,6 +171,29 @@ const authSlice = createSlice({
             })
             .addCase(updateUserProfile.pending, (state) => {
                 state.isLoading = true
+            })
+            .addCase(updateAccountSettings.fulfilled, (state, action) => {
+                if (state.user?.userId) {
+                    if (action.payload.username !== undefined) state.user.userId.username = action.payload.username;
+                    if (action.payload.isPrivate !== undefined) state.user.userId.isPrivate = action.payload.isPrivate;
+                    if (action.payload.pushEnabled !== undefined) state.user.userId.pushEnabled = action.payload.pushEnabled;
+                }
+            })
+            .addCase(getBlockedUsers.fulfilled, (state, action) => {
+                state.blockedUsers = action.payload.blockedUsers || [];
+            })
+            .addCase(blockUser.fulfilled, (state, action) => {
+                // Optimistic-ish: remove from connections too, matches the
+                // backend deleting the connection on block.
+                state.connection = state.connection.filter(
+                    (c) => c.userId?._id !== action.payload.targetId && c.connectionId?._id !== action.payload.targetId
+                );
+                state.connectionRequest = state.connectionRequest.filter(
+                    (c) => c.userId?._id !== action.payload.targetId
+                );
+            })
+            .addCase(unblockUser.fulfilled, (state, action) => {
+                state.blockedUsers = state.blockedUsers.filter((u) => u._id !== action.payload.targetId);
             })
             .addCase(logout.fulfilled, (state) => {
                 state.user = null;

--- a/frontend/src/pages/settings/blocked_accounts/BlockedAccounts.module.css
+++ b/frontend/src/pages/settings/blocked_accounts/BlockedAccounts.module.css
@@ -1,0 +1,94 @@
+.container {
+    max-width: 560px;
+    margin: 0 auto;
+    padding: 24px 20px 100px;
+}
+
+.backBtn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: none;
+    border: none;
+    color: var(--mt-ink2);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    padding: 0;
+    margin-bottom: 12px;
+}
+
+.backIcon {
+    width: 18px;
+    height: 18px;
+}
+
+.title {
+    font-family: var(--mt-font-display);
+    font-size: 28px;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    background: var(--mt-grad);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    display: inline-block;
+    margin-bottom: 20px;
+}
+
+.group {
+    background: var(--mt-surface);
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow: var(--mt-shadow);
+    border: 1px solid var(--mt-border);
+}
+
+.row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--mt-border);
+}
+
+.row:last-child {
+    border-bottom: none;
+}
+
+.avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.info {
+    flex: 1;
+    min-width: 0;
+}
+
+.info h4 {
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--mt-ink);
+    margin: 0;
+}
+
+.info p {
+    font-size: 12px;
+    color: var(--mt-ink3);
+    margin: 2px 0 0;
+}
+
+.unblockBtn {
+    flex-shrink: 0;
+    padding: 8px 16px;
+    border-radius: 999px;
+    border: 1px solid var(--mt-border);
+    background: var(--mt-sunken);
+    color: var(--mt-ink);
+    font-size: 12.5px;
+    font-weight: 600;
+    cursor: pointer;
+}

--- a/frontend/src/pages/settings/blocked_accounts/index.jsx
+++ b/frontend/src/pages/settings/blocked_accounts/index.jsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { useDispatch, useSelector } from 'react-redux';
+import DashboardLayout from '@/layout/DashboardLayout';
+import BlastLoader from '@/Components/ui/BlastLoader';
+import EmptyState from '@/Components/ui/EmptyState';
+import { useToast } from '@/Components/Toast';
+import { getBlockedUsers, unblockUser } from '@/config/redux/action/authAction';
+import { ChevronLeft, UserX } from 'lucide-react';
+import styles from './BlockedAccounts.module.css';
+
+export default function BlockedAccountsPage() {
+    const router = useRouter();
+    const dispatch = useDispatch();
+    const toast = useToast();
+    const { blockedUsers } = useSelector((state) => state.auth);
+    const [loaded, setLoaded] = useState(false);
+
+    useEffect(() => {
+        dispatch(getBlockedUsers()).finally(() => setLoaded(true));
+    }, [dispatch]);
+
+    const handleUnblock = async (targetId) => {
+        const result = await dispatch(unblockUser(targetId));
+        if (unblockUser.fulfilled.match(result)) {
+            toast.success('Account unblocked');
+        } else {
+            toast.error(result.payload?.message || 'Failed to unblock');
+        }
+    };
+
+    return (
+        <DashboardLayout>
+            <div className={styles.container}>
+                <button className={styles.backBtn} onClick={() => router.push('/settings')}>
+                    <ChevronLeft className={styles.backIcon} />
+                    Back to Settings
+                </button>
+                <h1 className={styles.title}>Blocked accounts</h1>
+
+                {!loaded ? (
+                    <div className="w-full flex items-center justify-center py-16">
+                        <BlastLoader size={48} />
+                    </div>
+                ) : blockedUsers.length === 0 ? (
+                    <EmptyState
+                        icon={UserX}
+                        title="No blocked accounts"
+                        description="Accounts you block will show up here — you can unblock them anytime."
+                    />
+                ) : (
+                    <div className={styles.group}>
+                        {blockedUsers.map((u) => (
+                            <div className={styles.row} key={u._id}>
+                                <img src={u.profilePicture || '/default-avatar.svg'} alt="" className={styles.avatar} />
+                                <div className={styles.info}>
+                                    <h4>{u.name}</h4>
+                                    <p>@{u.username}</p>
+                                </div>
+                                <button className={styles.unblockBtn} onClick={() => handleUnblock(u._id)}>
+                                    Unblock
+                                </button>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </DashboardLayout>
+    );
+}

--- a/frontend/src/pages/settings/index.jsx
+++ b/frontend/src/pages/settings/index.jsx
@@ -2,7 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useSelector, useDispatch } from 'react-redux';
 import styles from './Settings.module.css';
-import { logout } from '@/config/redux/action/authAction/index';
+import { logout, updateAccountSettings } from '@/config/redux/action/authAction/index';
+import { useToast } from '@/Components/Toast';
 import {
     ChevronRight,
     Moon,
@@ -13,17 +14,28 @@ import {
     LogOut,
     UsersRound,
     Bell,
+    UserCog,
+    Mail,
+    KeyRound,
+    Lock,
+    UserX,
+    BellRing,
 } from 'lucide-react';
 import DashboardLayout from '@/layout/DashboardLayout';
 import SettingsItem from '@/Components/ui/SettingsItem';
+import Toggle from '@/Components/ui/Toggle';
 import { useNotification } from '@/Components/NotificationProvider';
 
 export default function Settings() {
     const router = useRouter();
     const dispatch = useDispatch();
+    const toast = useToast();
     const { user } = useSelector(state => state.auth);
     const { unreadCount } = useNotification();
     const [theme, setTheme] = useState('system'); // light, dark, system
+    const [showUsernameModal, setShowUsernameModal] = useState(false);
+    const [usernameInput, setUsernameInput] = useState('');
+    const [savingUsername, setSavingUsername] = useState(false);
 
     useEffect(() => {
         const savedTheme = localStorage.getItem('theme') || 'system';
@@ -44,6 +56,44 @@ export default function Settings() {
         if (window.confirm("Are you sure you want to log out?")) {
             dispatch(logout());
             router.push('/login');
+        }
+    };
+
+    const openUsernameModal = () => {
+        setUsernameInput(user?.userId?.username || '');
+        setShowUsernameModal(true);
+    };
+
+    const handleSaveUsername = async () => {
+        const trimmed = usernameInput.trim();
+        if (!trimmed || trimmed === user?.userId?.username) {
+            setShowUsernameModal(false);
+            return;
+        }
+        setSavingUsername(true);
+        const result = await dispatch(updateAccountSettings({ username: trimmed }));
+        setSavingUsername(false);
+        if (updateAccountSettings.fulfilled.match(result)) {
+            toast.success('Username updated');
+            setShowUsernameModal(false);
+        } else {
+            toast.error(result.payload?.message || 'Failed to update username');
+        }
+    };
+
+    const handleTogglePrivate = async (next) => {
+        const result = await dispatch(updateAccountSettings({ isPrivate: next }));
+        if (updateAccountSettings.fulfilled.match(result)) {
+            toast.success(next ? 'Your account is now private' : 'Your account is now public');
+        } else {
+            toast.error(result.payload?.message || 'Failed to update');
+        }
+    };
+
+    const handleTogglePush = async (next) => {
+        const result = await dispatch(updateAccountSettings({ pushEnabled: next }));
+        if (!updateAccountSettings.fulfilled.match(result)) {
+            toast.error(result.payload?.message || 'Failed to update');
         }
     };
 
@@ -96,9 +146,71 @@ export default function Settings() {
                     />
                 </div>
 
+                {/* Account */}
+                <div className={styles.sectionTitle}>Account</div>
+                <div className={`${styles.group} mt-enter`} style={{ animationDelay: '50ms' }}>
+                    <SettingsItem
+                        icon={UserCog}
+                        label="Username"
+                        sub={`@${user?.userId?.username || ''}`}
+                        onClick={openUsernameModal}
+                    />
+                    <SettingsItem
+                        icon={Mail}
+                        label="Email"
+                        sub={user?.userId?.email || ''}
+                    />
+                    {!user?.userId?.googleId && (
+                        <SettingsItem
+                            icon={KeyRound}
+                            label="Password"
+                            sub="Change your password"
+                            onClick={() => router.push('/forgot-password')}
+                        />
+                    )}
+                </div>
+
+                {/* Privacy */}
+                <div className={styles.sectionTitle}>Privacy</div>
+                <div className={`${styles.group} mt-enter`} style={{ animationDelay: '70ms' }}>
+                    <SettingsItem
+                        icon={Lock}
+                        label="Private account"
+                        sub="Only connections can see your profile and posts"
+                        right={
+                            <Toggle
+                                checked={!!user?.userId?.isPrivate}
+                                onChange={handleTogglePrivate}
+                            />
+                        }
+                    />
+                    <SettingsItem
+                        icon={UserX}
+                        label="Blocked accounts"
+                        sub="People you've blocked"
+                        onClick={() => router.push('/settings/blocked_accounts')}
+                    />
+                </div>
+
+                {/* Notifications */}
+                <div className={styles.sectionTitle}>Notifications</div>
+                <div className={`${styles.group} mt-enter`} style={{ animationDelay: '90ms' }}>
+                    <SettingsItem
+                        icon={BellRing}
+                        label="Push notifications"
+                        sub="Get notified even when the tab is closed"
+                        right={
+                            <Toggle
+                                checked={user?.userId?.pushEnabled !== false}
+                                onChange={handleTogglePush}
+                            />
+                        }
+                    />
+                </div>
+
                 {/* Appearance */}
                 <div className={styles.sectionTitle}>Appearance</div>
-                <div className={`${styles.group} mt-enter`} style={{ animationDelay: '60ms' }}>
+                <div className={`${styles.group} mt-enter`} style={{ animationDelay: '110ms' }}>
                     <div className={styles.item}>
                         <div className={styles.iconBox}>
                             <MoonStar className={styles.icon} />
@@ -134,8 +246,8 @@ export default function Settings() {
                 </div>
 
                 {/* Privacy & Support */}
-                <div className={styles.sectionTitle}>Privacy & Support</div>
-                <div className={`${styles.group} mt-enter`} style={{ animationDelay: '120ms' }}>
+                <div className={styles.sectionTitle}>Support</div>
+                <div className={`${styles.group} mt-enter`} style={{ animationDelay: '130ms' }}>
                     <SettingsItem
                         icon={ShieldCheck}
                         label="Privacy Policy"
@@ -151,7 +263,7 @@ export default function Settings() {
                 </div>
 
                 {/* Account Actions */}
-                <div className={`${styles.group} mt-enter`} style={{ animationDelay: '180ms' }}>
+                <div className={`${styles.group} mt-enter`} style={{ animationDelay: '150ms' }}>
                     <button className={`${styles.logoutBtn} mt-btn-lift`} onClick={handleLogout}>
                         <LogOut className={styles.logoutIcon} />
                         Log out
@@ -164,6 +276,38 @@ export default function Settings() {
                     Log out, which is exactly the kind of thing a misclick
                     lands on. It's reachable only through Help & Support's
                     guide now, adding real deliberate steps in between. */}
+
+                {showUsernameModal && (
+                    <div className={styles.modalOverlay} onClick={() => !savingUsername && setShowUsernameModal(false)}>
+                        <div className={styles.modalBox} onClick={(e) => e.stopPropagation()}>
+                            <h3 className={styles.modalTitle}>Change username</h3>
+                            <input
+                                type="text"
+                                value={usernameInput}
+                                onChange={(e) => setUsernameInput(e.target.value.replace(/\s/g, ''))}
+                                className={styles.modalInput}
+                                placeholder="username"
+                            />
+                            <div className={styles.modalActions}>
+                                <button
+                                    className={styles.modalCancelBtn}
+                                    onClick={() => setShowUsernameModal(false)}
+                                    disabled={savingUsername}
+                                >
+                                    Cancel
+                                </button>
+                                <button
+                                    className={styles.modalDeleteBtn}
+                                    onClick={handleSaveUsername}
+                                    disabled={savingUsername || !usernameInput.trim()}
+                                    style={{ background: 'var(--mt-grad)' }}
+                                >
+                                    {savingUsername ? 'Saving…' : 'Save'}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                )}
 
                 <div className={styles.footer}>
                     <p>Mitrata App v1.2.0</p>

--- a/frontend/src/pages/view_profile/[username].jsx
+++ b/frontend/src/pages/view_profile/[username].jsx
@@ -5,23 +5,42 @@ import DashboardLayout from '@/layout/DashboardLayout'
 import { useRouter } from 'next/router'
 import { useDispatch, useSelector } from 'react-redux'
 import { getPostsByUsername } from '@/config/redux/action/postAction'
-import { downloadResume, getConnectionRequest, sendConnectionRequest } from '@/config/redux/action/authAction'
-import serverAxios from '@/config/serverAxios'
-import { UserPlus, Check, Download, ArrowRight } from 'lucide-react'
+import { downloadResume, getConnectionRequest, sendConnectionRequest, blockUser } from '@/config/redux/action/authAction'
+import { UserPlus, Check, Download, ArrowRight, Lock, UserX } from 'lucide-react'
 import ReportMenu from '@/Components/ReportMenu'
 import BlastLoader from '@/Components/ui/BlastLoader'
+import PageLoader from '@/Components/ui/PageLoader'
+import { useToast } from '@/Components/Toast'
 
-export default function viewProfilePage({ userProfile }) {
+export default function viewProfilePage() {
     const router = useRouter()
     const dispatch = useDispatch()
+    const toast = useToast()
     const postState = useSelector((state) => state.post)
     const userState = useSelector((state) => state.auth)
 
     const [mounted, setMounted] = useState(false);
+    // Fetched client-side (was getServerSideProps — that runs with no access
+    // to the browser's token at all, which broke outright the moment this
+    // endpoint started requiring auth to gate private accounts correctly).
+    const [userProfile, setUserProfile] = useState(null);
+    const [profileLoaded, setProfileLoaded] = useState(false);
     const [userPost, setUserPost] = useState([])
     const [isCurrentUserInConnection, setIsCurrentUserInConnection] = useState(false)
-    const [isConnectionNull, setConnectionNull] = useState(true)
-    const [connectionStatus, setConnectionStatus] = useState(undefined); // NEW STATE
+    const [connectionStatus, setConnectionStatus] = useState(undefined);
+
+    useEffect(() => {
+        setMounted(true);
+    }, []);
+
+    useEffect(() => {
+        if (!router.isReady || !router.query.username) return;
+        setProfileLoaded(false);
+        clientServer.get('/user/get_user_based_on_username', { params: { username: router.query.username } })
+            .then(({ data }) => setUserProfile(data.profile || null))
+            .catch(() => setUserProfile(null))
+            .finally(() => setProfileLoaded(true));
+    }, [router.isReady, router.query.username]);
 
     useEffect(() => {
         const connections = userState.connection;
@@ -46,10 +65,6 @@ export default function viewProfilePage({ userProfile }) {
     }, [userState.connection, userProfile?.userId?._id]);
 
     useEffect(() => {
-        setMounted(true);
-    }, []);
-
-    useEffect(() => {
         const token = localStorage.getItem('token');
         if (token) {
             dispatch(getConnectionRequest())
@@ -70,31 +85,26 @@ export default function viewProfilePage({ userProfile }) {
         setUserPost(postState.userPosts || []);
     }, [postState.userPosts])
 
-    useEffect(() => {
-        const connections = userState.connection;
-        const profileId = userProfile?.userId?._id;
-
-        if (connections && Array.isArray(connections) && profileId) {
-            const foundConn = connections.find(conn => {
-                const connId = conn.connectionId?._id || conn.connectionId;
-                const userId = conn.userId?._id || conn.userId;
-                return connId === profileId || userId === profileId;
-            });
-
-            if (foundConn) {
-                setIsCurrentUserInConnection(true);
-                setConnectionNull(foundConn.status_accepted === null);
-            } else {
-                setIsCurrentUserInConnection(false);
-            }
+    const handleBlock = async () => {
+        if (!window.confirm(`Block @${userProfile.userId.username}? They won't be able to message or connect with you.`)) return;
+        const result = await dispatch(blockUser(userProfile.userId._id));
+        if (blockUser.fulfilled.match(result)) {
+            toast.success('User blocked');
+            router.push('/my_network');
+        } else {
+            toast.error(result.payload?.message || 'Failed to block user');
         }
-    }, [userState.connection, userProfile?.userId?._id]);
+    };
 
     // Placed after every hook above (not before, as this used to be) — a
     // conditional `return` before some of this component's hooks meant
     // client-side-navigating from a valid profile to a missing one reused
     // the same component instance with fewer hooks called on the next
     // render, which React throws on ("Rendered fewer hooks than expected").
+    if (!profileLoaded) {
+        return <PageLoader />;
+    }
+
     if (!userProfile) {
         return (
             <DashboardLayout>
@@ -122,8 +132,42 @@ export default function viewProfilePage({ userProfile }) {
         );
     }
 
+    // Private account, viewer isn't a connection — the backend sends back a
+    // limited card (name/username/avatar only) instead of the real profile.
+    if (userProfile.isPrivateLocked) {
+        return (
+            <DashboardLayout>
+                <div style={{ textAlign: "center", padding: "60px 20px", color: "var(--mt-ink)" }}>
+                    <img
+                        src={userProfile.userId?.profilePicture || "/default-avatar.svg"}
+                        alt="profile"
+                        style={{ width: 88, height: 88, borderRadius: "50%", objectFit: "cover", margin: "0 auto 16px" }}
+                    />
+                    <h2 style={{ fontFamily: "var(--mt-font-display)", fontWeight: 600 }}>{userProfile.userId?.name}</h2>
+                    <p style={{ color: "var(--mt-ink2)", marginBottom: 4 }}>@{userProfile.userId?.username}</p>
+                    <div style={{ display: "flex", alignItems: "center", justifyContent: "center", gap: 6, color: "var(--mt-ink3)", marginTop: 16 }}>
+                        <Lock size={16} strokeWidth={1.8} />
+                        <span>This account is private</span>
+                    </div>
+                    <p style={{ color: "var(--mt-ink3)", fontSize: 13, maxWidth: 320, margin: "8px auto 20px" }}>
+                        Connect with {userProfile.userId?.name} to see their posts and profile.
+                    </p>
+                    {isCurrentUserInConnection && connectionStatus === null ? (
+                        <button className={styles.pendingButton} disabled>Pending</button>
+                    ) : (
+                        <button
+                            className={`${styles.connectButton} mt-btn-lift`}
+                            onClick={() => dispatch(sendConnectionRequest({ connectionId: userProfile.userId._id }))}
+                        >
+                            <UserPlus size={15} strokeWidth={2} /> Connect
+                        </button>
+                    )}
+                </div>
+            </DashboardLayout>
+        );
+    }
+
     const recentPosts = userPost.slice(0, 3);
-    const hasMorePosts = userPost.length > 3;
 
     const handleDownloadResume = async () => {
         const res = await dispatch(downloadResume({ connectionId: userProfile.userId._id }));
@@ -182,6 +226,9 @@ export default function viewProfilePage({ userProfile }) {
                                     <p>Resume</p>
                                 </button>
                                 <ReportMenu targetType="user" targetId={userProfile.userId._id} />
+                                <button className={`${styles.resumeButton} mt-btn-lift`} onClick={handleBlock} title="Block user">
+                                    <UserX size={16} strokeWidth={1.8} />
+                                </button>
                             </div>
                         </div>
                     </div>
@@ -255,34 +302,8 @@ export default function viewProfilePage({ userProfile }) {
         </div>
     );
 
-
-
-
     // CRITICAL: Ensure this logic runs AFTER ProfileContent is defined
     if (!mounted) return ProfileContent;
 
     return <DashboardLayout>{ProfileContent}</DashboardLayout>;
-}
-
-export async function getServerSideProps(context) {
-    try {
-        // Ensure this path matches EXACTLY what worked in your Postman/Local tests
-        const req = await serverAxios.get('/user/get_user_based_on_username', {
-            params: { username: context.query.username }
-        });
-
-        return {
-            props: {
-                userProfile: req.data.profile || null
-            }
-        };
-    } catch (error) {
-        console.error("Profile Fetch Error:", error.response?.status);
-        return {
-            props: {
-                userProfile: null,
-                error: "Profile not found"
-            }
-        };
-    }
 }


### PR DESCRIPTION
## Summary
- Private accounts: profile/posts hidden from non-connections (locked payload, not a leaking 404/403)
- Blocking: removes any existing connection, blocks future requests either direction
- Per-user push notification preference respected by sendPush
- Settings: real Account (username/email/password), Privacy (private toggle, blocked accounts list), Notifications (push toggle) sections
- view_profile converted from SSR (getServerSideProps) to client-side fetch, since the profile route now requires auth to gate private accounts

## Test plan
- [ ] Toggle private account, confirm a non-connection sees the locked card, not the full profile
- [ ] Confirm posts-by-username also gates for private accounts
- [ ] Block a user, confirm existing connection removed and reconnection blocked
- [ ] Toggle push off, confirm sendPush no-ops for that user
- [ ] Change username via Settings modal
- [ ] `npx next build` clean (already verified)