### PR TITLE
Quiet hours for push notifications

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .env
 .env.local
 api.http
+.vercel

--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -559,7 +559,7 @@ export const updateUserProfile = async (req, res) => {
 // Profile document's fields.
 export const updateAccountSettings = async (req, res) => {
     try {
-        const { username, isPrivate, pushEnabled } = req.body;
+        const { username, isPrivate, pushEnabled, quietHours } = req.body;
         const user = await User.findById(req.userId);
         if (!user) return res.status(404).json({ message: "User not found" });
 
@@ -576,8 +576,28 @@ export const updateAccountSettings = async (req, res) => {
         if (isPrivate !== undefined) user.isPrivate = !!isPrivate;
         if (pushEnabled !== undefined) user.pushEnabled = !!pushEnabled;
 
+        if (quietHours !== undefined) {
+            const timeRegex = /^([01]\d|2[0-3]):[0-5]\d$/;
+            if (quietHours.start !== undefined && !timeRegex.test(quietHours.start)) {
+                return res.status(400).json({ message: "quietHours.start must be HH:mm" });
+            }
+            if (quietHours.end !== undefined && !timeRegex.test(quietHours.end)) {
+                return res.status(400).json({ message: "quietHours.end must be HH:mm" });
+            }
+            if (quietHours.enabled !== undefined) user.quietHours.enabled = !!quietHours.enabled;
+            if (quietHours.start !== undefined) user.quietHours.start = quietHours.start;
+            if (quietHours.end !== undefined) user.quietHours.end = quietHours.end;
+            if (quietHours.timezone !== undefined) user.quietHours.timezone = quietHours.timezone;
+        }
+
         await user.save();
-        return res.json({ message: "Updated successfully!", isPrivate: user.isPrivate, pushEnabled: user.pushEnabled, username: user.username });
+        return res.json({
+            message: "Updated successfully!",
+            isPrivate: user.isPrivate,
+            pushEnabled: user.pushEnabled,
+            username: user.username,
+            quietHours: user.quietHours
+        });
     } catch (error) {
         if (error.code === 11000) {
             return res.status(400).json({ message: "Username already taken" });
@@ -646,7 +666,7 @@ export const getUserAndProfile = async (req, res) => {
         // req.userId is already a verified-to-exist user (see verifyToken) —
         // no need to re-fetch the User doc just to read its own id back.
         const userProfile = await Profile.findOne({ userId: req.userId })
-            .populate("userId", "name email username profilePicture coverPhoto createAt role googleId isPrivate pushEnabled");
+            .populate("userId", "name email username profilePicture coverPhoto createAt role googleId isPrivate pushEnabled quietHours");
 
         if (!userProfile) {
             return res.status(404).json({ message: "profile not found" });

--- a/backend/models/users.model.js
+++ b/backend/models/users.model.js
@@ -76,6 +76,16 @@ const userSchema = new mongoose.Schema({
         type: Boolean,
         default: true
     },
+    // A single daily on/off window in the user's own local time (captured as
+    // an IANA zone name when they set it, e.g. "Asia/Kolkata") — not a
+    // per-day schedule. sendPush checks the current time against this before
+    // sending; start > end means the window wraps past midnight (22:00-07:00).
+    quietHours: {
+        enabled: { type: Boolean, default: false },
+        start: { type: String, default: "22:00" },
+        end: { type: String, default: "07:00" },
+        timezone: { type: String, default: "UTC" },
+    },
     // TOTP two-step verification. `secret` holds a pending (unconfirmed)
     // secret while the user is mid-setup, and the confirmed one once
     // `enabled`. `select: false` keeps these out of any query that doesn't

--- a/backend/utils/push.js
+++ b/backend/utils/push.js
@@ -1,6 +1,29 @@
 import { messaging } from "../config/firebase.js";
 import User from "../models/users.model.js";
 
+// True if "now" falls inside the user's quiet-hours window, evaluated in
+// their own local time (native Intl, no tz library needed). start > end means
+// the window crosses midnight (e.g. 22:00-07:00).
+const isWithinQuietHours = ({ start, end, timezone }) => {
+    try {
+        const parts = new Intl.DateTimeFormat("en-GB", {
+            timeZone: timezone || "UTC", hour: "2-digit", minute: "2-digit", hour12: false
+        }).formatToParts(new Date());
+        const nowMinutes = Number(parts.find(p => p.type === "hour").value) * 60
+            + Number(parts.find(p => p.type === "minute").value);
+        const [sh, sm] = start.split(":").map(Number);
+        const [eh, em] = end.split(":").map(Number);
+        const startMinutes = sh * 60 + sm;
+        const endMinutes = eh * 60 + em;
+        if (startMinutes === endMinutes) return false;
+        return startMinutes < endMinutes
+            ? nowMinutes >= startMinutes && nowMinutes < endMinutes
+            : nowMinutes >= startMinutes || nowMinutes < endMinutes;
+    } catch {
+        return false; // unrecognized timezone string — fail open, don't block real pushes
+    }
+};
+
 // Sends a push to every device a user has registered — used alongside the
 // existing Notification.create()+socket.emit() calls (message, connection
 // request/accepted, likes, comments) so someone still gets notified even
@@ -8,8 +31,9 @@ import User from "../models/users.model.js";
 export const sendPush = async (userId, { title, body, data = {} }) => {
     if (!messaging) return; // not configured — same no-op pattern as sendMail
 
-    const user = await User.findById(userId).select("fcmTokens pushEnabled").lean();
+    const user = await User.findById(userId).select("fcmTokens pushEnabled quietHours").lean();
     if (user?.pushEnabled === false) return; // user turned push off in Settings
+    if (user?.quietHours?.enabled && isWithinQuietHours(user.quietHours)) return;
     const tokens = user?.fcmTokens || [];
     if (tokens.length === 0) return;
 

--- a/frontend/src/config/redux/reducer/authReducer/index.js
+++ b/frontend/src/config/redux/reducer/authReducer/index.js
@@ -208,6 +208,7 @@ const authSlice = createSlice({
                     if (action.payload.username !== undefined) state.user.userId.username = action.payload.username;
                     if (action.payload.isPrivate !== undefined) state.user.userId.isPrivate = action.payload.isPrivate;
                     if (action.payload.pushEnabled !== undefined) state.user.userId.pushEnabled = action.payload.pushEnabled;
+                    if (action.payload.quietHours !== undefined) state.user.userId.quietHours = action.payload.quietHours;
                 }
             })
             .addCase(getBlockedUsers.fulfilled, (state, action) => {

--- a/frontend/src/pages/settings/index.jsx
+++ b/frontend/src/pages/settings/index.jsx
@@ -105,6 +105,45 @@ export default function Settings() {
         }
     };
 
+    const quietHours = user?.userId?.quietHours || { enabled: false, start: '22:00', end: '07:00' };
+    const [quietStart, setQuietStart] = useState(quietHours.start);
+    const [quietEnd, setQuietEnd] = useState(quietHours.end);
+
+    useEffect(() => {
+        setQuietStart(quietHours.start);
+        setQuietEnd(quietHours.end);
+    }, [quietHours.start, quietHours.end]);
+
+    const handleToggleQuietHours = async (next) => {
+        const result = await dispatch(updateAccountSettings({
+            quietHours: {
+                enabled: next,
+                start: quietStart,
+                end: quietEnd,
+                timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            }
+        }));
+        if (!updateAccountSettings.fulfilled.match(result)) {
+            toast.error(result.payload?.message || 'Failed to update');
+        }
+    };
+
+    const handleSaveQuietHoursWindow = async () => {
+        const result = await dispatch(updateAccountSettings({
+            quietHours: {
+                enabled: true,
+                start: quietStart,
+                end: quietEnd,
+                timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            }
+        }));
+        if (updateAccountSettings.fulfilled.match(result)) {
+            toast.success('Quiet hours updated');
+        } else {
+            toast.error(result.payload?.message || 'Failed to update');
+        }
+    };
+
     return (
                         <DashboardLayout>
         <div className={styles.container}>
@@ -248,6 +287,41 @@ export default function Settings() {
                             />
                         }
                     />
+                    <SettingsItem
+                        icon={MoonStar}
+                        label="Quiet hours"
+                        sub={quietHours.enabled ? `Muted ${quietStart}–${quietEnd}` : "Mute push notifications overnight"}
+                        right={
+                            <Toggle
+                                checked={!!quietHours.enabled}
+                                onChange={handleToggleQuietHours}
+                            />
+                        }
+                    />
+                    {quietHours.enabled && (
+                        <div className={styles.item} style={{ paddingTop: 0 }}>
+                            <div className={styles.labelBlock} style={{ flex: 'none' }} />
+                            <div style={{ display: 'flex', alignItems: 'center', gap: 10, flex: 1 }}>
+                                <input
+                                    type="time"
+                                    value={quietStart}
+                                    onChange={(e) => setQuietStart(e.target.value)}
+                                    onBlur={handleSaveQuietHoursWindow}
+                                    className={styles.modalInput}
+                                    style={{ width: 'auto', marginBottom: 0 }}
+                                />
+                                <span style={{ color: 'var(--mt-ink3)', fontSize: 12.5 }}>to</span>
+                                <input
+                                    type="time"
+                                    value={quietEnd}
+                                    onChange={(e) => setQuietEnd(e.target.value)}
+                                    onBlur={handleSaveQuietHoursWindow}
+                                    className={styles.modalInput}
+                                    style={{ width: 'auto', marginBottom: 0 }}
+                                />
+                            </div>
+                        </div>
+                    )}
                 </div>
 
                 {/* Appearance */}


### PR DESCRIPTION
## Summary
- Daily on/off window (e.g. 22:00-07:00) muting push notifications, in the user's own local time via IANA timezone captured client-side when they turn it on
- `sendPush` checks it alongside the existing `pushEnabled` check, same no-op-if-blocked pattern
- Settings > Notifications gets a Quiet hours toggle + inline start/end time inputs

## Test plan
- [x] Boundary-condition assertions for the wraparound window math (22:00-07:00 style) run clean
- [x] `npx next build` clean
- [ ] Toggle on in Settings, confirm a push sent during the window is suppressed and one outside it isn't