### PR TITLE
Real multi-device sessions + login activity page

### DIFF
--- a/backend/controllers/admin.controller.js
+++ b/backend/controllers/admin.controller.js
@@ -44,7 +44,7 @@ export const setUserActive = async (req, res) => {
         if (user.role === "admin") return res.status(400).json({ message: "Cannot suspend an admin account" });
 
         user.active = !!active;
-        if (!user.active) user.refreshTokenHash = null; // force logout on suspend
+        if (!user.active) user.sessions = []; // force logout on suspend, every device
         await user.save();
 
         return res.json({ message: active ? "User reactivated" : "User suspended", active: user.active });

--- a/backend/controllers/otp.controller.js
+++ b/backend/controllers/otp.controller.js
@@ -108,7 +108,7 @@ export const verifyOtp = async (req, res) => {
             // Auto-login on successful verification — matches the UX of every
             // other "confirm and continue" flow in the app rather than
             // bouncing the user to a separate login step right after signup.
-            const accessToken = await issueSession(res, user);
+            const accessToken = await issueSession(res, user, req);
             return res.json({ message: "Email verified", verified: true, token: accessToken });
         }
 
@@ -165,7 +165,7 @@ export const resetPassword = async (req, res) => {
         // Reset invalidates every existing session, not just the current
         // device — a password reset is exactly the moment you want any
         // stolen/stale session logged out too.
-        user.refreshTokenHash = null;
+        user.sessions = [];
         await user.save();
 
         return res.json({ message: "Password reset successfully" });

--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -27,7 +27,7 @@ import { authenticator } from "otplib";
 import QRCode from "qrcode";
 
 import { issueOtp } from "./otp.controller.js";
-import { issueSession, hashToken, refreshCookieName, refreshCookieOptions, signTwoFactorChallenge, verifyTwoFactorChallenge } from "../utils/session.js";
+import { issueSession, hashToken, refreshCookieName, refreshCookieOptions, signTwoFactorChallenge, verifyTwoFactorChallenge, describeDevice } from "../utils/session.js";
 import { sendPush } from "../utils/push.js";
 
 const googleClient = process.env.GOOGLE_CLIENT_ID ? new OAuth2Client(process.env.GOOGLE_CLIENT_ID) : null;
@@ -130,7 +130,7 @@ export const login = async (req, res) => {
             return res.json({ requires2FA: true, challengeToken: signTwoFactorChallenge(user._id) });
         }
 
-        const accessToken = await issueSession(res, user);
+        const accessToken = await issueSession(res, user, req);
         return res.json({ token: accessToken });
 
     } catch (error) {
@@ -173,7 +173,7 @@ export const verifyTwoFactorLogin = async (req, res) => {
 
         if (usedBackupCode) await user.save();
 
-        const accessToken = await issueSession(res, user);
+        const accessToken = await issueSession(res, user, req);
         return res.json({ token: accessToken, usedBackupCode });
     } catch (error) {
         return res.status(500).json({ message: error.message });
@@ -258,6 +258,59 @@ export const disableTwoFactor = async (req, res) => {
     }
 };
 
+// Powers Settings > Login activity. "isCurrent" is worked out by hashing
+// this very request's own refresh cookie and matching it against the list —
+// no separate "current session id" needs to be threaded through anywhere.
+export const getSessions = async (req, res) => {
+    try {
+        const user = await User.findById(req.userId).select("sessions");
+        const currentToken = req.cookies?.[refreshCookieName(req.userId)];
+        const currentHash = currentToken ? hashToken(currentToken) : null;
+
+        const sessions = (user?.sessions || [])
+            .slice()
+            .sort((a, b) => new Date(b.lastActiveAt) - new Date(a.lastActiveAt))
+            .map((s) => ({
+                id: s._id,
+                device: describeDevice(s.userAgent),
+                ip: s.ip,
+                createdAt: s.createdAt,
+                lastActiveAt: s.lastActiveAt,
+                isCurrent: s.tokenHash === currentHash,
+            }));
+
+        return res.json({ sessions });
+    } catch (error) {
+        return res.status(500).json({ message: error.message });
+    }
+};
+
+export const revokeSession = async (req, res) => {
+    try {
+        const { id } = req.params;
+        await User.findByIdAndUpdate(req.userId, { $pull: { sessions: { _id: id } } });
+        return res.json({ message: "Signed out of that device" });
+    } catch (error) {
+        return res.status(500).json({ message: error.message });
+    }
+};
+
+export const revokeOtherSessions = async (req, res) => {
+    try {
+        const currentToken = req.cookies?.[refreshCookieName(req.userId)];
+        const currentHash = currentToken ? hashToken(currentToken) : null;
+
+        const user = await User.findById(req.userId);
+        if (!user) return res.status(404).json({ message: "User not found" });
+        user.sessions = currentHash ? user.sessions.filter((s) => s.tokenHash === currentHash) : [];
+        await user.save();
+
+        return res.json({ message: "Signed out of all other devices" });
+    } catch (error) {
+        return res.status(500).json({ message: error.message });
+    }
+};
+
 // Shared by both the popup flow (googleLogin) and the redirect-fallback
 // flow (googleLoginCallback) — Safari's Intelligent Tracking Prevention and
 // Edge's Tracking Prevention both block the popup+iframe handshake GSI's
@@ -317,7 +370,7 @@ const verifyAndUpsertGoogleUser = async (idToken) => {
 export const googleLogin = async (req, res) => {
     try {
         const user = await verifyAndUpsertGoogleUser(req.body.idToken);
-        const accessToken = await issueSession(res, user);
+        const accessToken = await issueSession(res, user, req);
         return res.json({ token: accessToken });
     } catch (error) {
         console.error("Google login error:", error.message);
@@ -335,7 +388,7 @@ export const googleLoginCallback = async (req, res) => {
     const failUrl = `${process.env.FRONTEND_URL}/login?googleError=1`;
     try {
         const user = await verifyAndUpsertGoogleUser(req.body.credential);
-        const accessToken = await issueSession(res, user);
+        const accessToken = await issueSession(res, user, req);
         return res.redirect(`${process.env.FRONTEND_URL}/login?googleToken=${accessToken}`);
     } catch (error) {
         console.error("Google login callback error:", error.message);
@@ -356,11 +409,16 @@ export const refreshAccessToken = async (req, res) => {
         const decoded = jwt.verify(token, process.env.JWT_REFRESH_SECRET || process.env.JWT_SECRET);
         const user = await User.findById(decoded.userId);
         if (!user || !user.active) return res.status(401).json({ message: "User no longer exists" });
-        if (user.refreshTokenHash !== hashToken(token)) {
+
+        const tokenHash = hashToken(token);
+        if (!user.sessions.some((s) => s.tokenHash === tokenHash)) {
             return res.status(401).json({ message: "Refresh token has been revoked" });
         }
+        // Rotating: this device's old session entry is replaced by the fresh
+        // one issueSession appends below, every other device's is untouched.
+        user.sessions = user.sessions.filter((s) => s.tokenHash !== tokenHash);
 
-        const accessToken = await issueSession(res, user); // rotate refresh token too
+        const accessToken = await issueSession(res, user, req); // rotate refresh token too
         return res.json({ token: accessToken });
     } catch (error) {
         return res.status(401).json({ message: "Refresh token invalid or expired, please login again" });
@@ -373,7 +431,10 @@ export const logout = async (req, res) => {
     try {
         const { userId } = req.body || {};
         if (userId) {
-            await User.findByIdAndUpdate(userId, { refreshTokenHash: null });
+            const token = req.cookies?.[refreshCookieName(userId)];
+            if (token) {
+                await User.findByIdAndUpdate(userId, { $pull: { sessions: { tokenHash: hashToken(token) } } });
+            }
             res.clearCookie(refreshCookieName(userId), refreshCookieOptions());
         }
         return res.json({ message: "Logged out successfully" });
@@ -408,12 +469,14 @@ export const switchAccount = async (req, res) => {
             res.clearCookie(cookieName, refreshCookieOptions());
             return res.status(401).json({ message: "Account unavailable", needsLogin: true });
         }
-        if (user.refreshTokenHash !== hashToken(token)) {
+        const tokenHash = hashToken(token);
+        if (!user.sessions.some((s) => s.tokenHash === tokenHash)) {
             res.clearCookie(cookieName, refreshCookieOptions());
             return res.status(401).json({ message: "Session expired, please log in again", needsLogin: true });
         }
+        user.sessions = user.sessions.filter((s) => s.tokenHash !== tokenHash);
 
-        const accessToken = await issueSession(res, user);
+        const accessToken = await issueSession(res, user, req);
         return res.json({ token: accessToken });
     } catch (error) {
         return res.status(500).json({ message: error.message });
@@ -1214,7 +1277,7 @@ export const deleteMyAccount = async (req, res) => {
 
         await User.deleteOne({ _id: userId });
 
-        res.clearCookie("refreshToken", refreshCookieOptions());
+        res.clearCookie(refreshCookieName(userId), refreshCookieOptions());
         return res.json({ message: "Account permanently deleted" });
     } catch (error) {
         console.error("Delete account error:", error);

--- a/backend/models/users.model.js
+++ b/backend/models/users.model.js
@@ -37,10 +37,18 @@ const userSchema = new mongoose.Schema({
         enum: ["user", "admin"],
         default: "user"
     },
-    refreshTokenHash: {
-        type: String,
-        default: null
-    },
+    // One entry per active refresh cookie — replaces the old single
+    // refreshTokenHash field, which meant logging in on a second device
+    // silently kicked the first one out (its hash no longer matched the one
+    // shared field). Now each device/browser keeps its own entry, which is
+    // also what powers the "login activity" list in Settings.
+    sessions: [{
+        tokenHash: { type: String, required: true },
+        userAgent: { type: String, default: "" },
+        ip: { type: String, default: "" },
+        createdAt: { type: Date, default: Date.now },
+        lastActiveAt: { type: Date, default: Date.now },
+    }],
     profilePicture: {
         type: String,
         default: 'https://res.cloudinary.com/detvfqvem/image/upload/v1767007231/default_qzkkui.jpg'

--- a/backend/routes/user.routes.js
+++ b/backend/routes/user.routes.js
@@ -1,6 +1,6 @@
 
 import multer from "multer";
-import { acceptConnectionRequest, downloadProfile, findSearchUser, getAllUserBasedOnUsername, getMyConnectionRequest, getUserAndProfile, login, logout, register, sendconnectionrequest, updateProfileData, updateUserProfile, updateAccountSettings, uploadCoverPhoto, uploadImage, uploadProfilePicture, whatAreMyConnection, searchUsers, getSuggestions, googleLogin, googleLoginCallback, refreshAccessToken, deleteMyAccount, switchAccount, registerFcmToken, unregisterFcmToken, blockUser, unblockUser, getBlockedUsers, verifyTwoFactorLogin, getTwoFactorStatus, setupTwoFactor, verifyTwoFactorSetup, disableTwoFactor } from "../controllers/user.controller.js";
+import { acceptConnectionRequest, downloadProfile, findSearchUser, getAllUserBasedOnUsername, getMyConnectionRequest, getUserAndProfile, login, logout, register, sendconnectionrequest, updateProfileData, updateUserProfile, updateAccountSettings, uploadCoverPhoto, uploadImage, uploadProfilePicture, whatAreMyConnection, searchUsers, getSuggestions, googleLogin, googleLoginCallback, refreshAccessToken, deleteMyAccount, switchAccount, registerFcmToken, unregisterFcmToken, blockUser, unblockUser, getBlockedUsers, verifyTwoFactorLogin, getTwoFactorStatus, setupTwoFactor, verifyTwoFactorSetup, disableTwoFactor, getSessions, revokeSession, revokeOtherSessions } from "../controllers/user.controller.js";
 import { sendOtp, verifyOtp, resendOtp, resetPassword } from "../controllers/otp.controller.js";
 import { createReport } from "../controllers/admin.controller.js";
 import { Router } from "express"
@@ -29,6 +29,10 @@ router.route('/user/2fa/status').get(verifyToken, getTwoFactorStatus);
 router.route('/user/2fa/setup').post(verifyToken, setupTwoFactor);
 router.route('/user/2fa/verify').post(verifyToken, verifyTwoFactorSetup);
 router.route('/user/2fa/disable').post(verifyToken, disableTwoFactor);
+
+router.route('/user/sessions').get(verifyToken, getSessions);
+router.route('/user/sessions/revoke_others').post(verifyToken, revokeOtherSessions);
+router.route('/user/sessions/:id').delete(verifyToken, revokeSession);
 
 // ============ REPORTING (any authenticated user) ============
 router.route('/report').post(verifyToken, createReport);

--- a/backend/utils/session.js
+++ b/backend/utils/session.js
@@ -16,6 +16,32 @@ const signRefreshToken = (userId) =>
 
 const hashToken = (token) => crypto.createHash("sha256").update(token).digest("hex");
 
+// One user account can have several concurrent sessions now (phone + laptop
+// + a future Flutter app) — capped so a compromised/scripted account can't
+// grow this array without bound; oldest dropped first.
+const MAX_SESSIONS_PER_USER = 10;
+
+// Rough device label parsed out of User-Agent for the login-activity list —
+// deliberately not a full UA-parsing dependency, just enough to tell "Chrome
+// on Windows" from "Safari on iPhone" at a glance.
+export const describeDevice = (userAgent = "") => {
+    const ua = userAgent || "";
+    let os = "Unknown OS";
+    if (/iPhone|iPad/.test(ua)) os = "iOS";
+    else if (/Android/.test(ua)) os = "Android";
+    else if (/Mac OS X/.test(ua)) os = "macOS";
+    else if (/Windows/.test(ua)) os = "Windows";
+    else if (/Linux/.test(ua)) os = "Linux";
+
+    let browser = "Unknown browser";
+    if (/Edg\//.test(ua)) browser = "Edge";
+    else if (/Chrome\//.test(ua) && !/Chromium/.test(ua)) browser = "Chrome";
+    else if (/Firefox\//.test(ua)) browser = "Firefox";
+    else if (/Safari\//.test(ua) && !/Chrome/.test(ua)) browser = "Safari";
+
+    return `${browser} on ${os}`;
+};
+
 // Keyed per account rather than one fixed "refreshToken" cookie name — this
 // is what lets a browser hold a real, long-lived (30-day) session for
 // several accounts at once (see switchAccount) without ever putting a
@@ -50,11 +76,24 @@ const setRefreshCookie = (res, refreshToken, userId) => {
 
 // Shared by login, googleLogin, refreshAccessToken, switchAccount, and
 // verifyOtp's signup-verified auto-login — every path that hands out a
-// fresh session.
-export const issueSession = async (res, user) => {
+// fresh session. `req` is optional (passed wherever available) purely to
+// label the session for the login-activity list — a missing one just means
+// that entry shows as "Unknown browser on Unknown OS", not a functional gap.
+export const issueSession = async (res, user, req = null) => {
     const accessToken = signAccessToken(user._id);
     const refreshToken = signRefreshToken(user._id);
-    user.refreshTokenHash = hashToken(refreshToken);
+
+    user.sessions = user.sessions || [];
+    user.sessions.push({
+        tokenHash: hashToken(refreshToken),
+        userAgent: req?.headers?.["user-agent"] || "",
+        ip: req?.ip || "",
+        createdAt: new Date(),
+        lastActiveAt: new Date(),
+    });
+    if (user.sessions.length > MAX_SESSIONS_PER_USER) {
+        user.sessions = user.sessions.slice(user.sessions.length - MAX_SESSIONS_PER_USER);
+    }
     await user.save();
     setRefreshCookie(res, refreshToken, user._id);
     return accessToken;

--- a/frontend/src/config/redux/action/authAction/index.js
+++ b/frontend/src/config/redux/action/authAction/index.js
@@ -106,6 +106,42 @@ export const disableTwoFactor = createAsyncThunk(
         }
     }
 )
+
+export const getSessions = createAsyncThunk(
+    "user/getSessions",
+    async (_arg, thunkApi) => {
+        try {
+            const response = await clientServer.get('/user/sessions');
+            return thunkApi.fulfillWithValue(response.data)
+        } catch (error) {
+            return thunkApi.rejectWithValue(error.response?.data || { message: "Failed to load" })
+        }
+    }
+)
+
+export const revokeSession = createAsyncThunk(
+    "user/revokeSession",
+    async (sessionId, thunkApi) => {
+        try {
+            const response = await clientServer.delete(`/user/sessions/${sessionId}`);
+            return thunkApi.fulfillWithValue({ sessionId, ...response.data })
+        } catch (error) {
+            return thunkApi.rejectWithValue(error.response?.data || { message: "Failed to sign out that device" })
+        }
+    }
+)
+
+export const revokeOtherSessions = createAsyncThunk(
+    "user/revokeOtherSessions",
+    async (_arg, thunkApi) => {
+        try {
+            const response = await clientServer.post('/user/sessions/revoke_others');
+            return thunkApi.fulfillWithValue(response.data)
+        } catch (error) {
+            return thunkApi.rejectWithValue(error.response?.data || { message: "Failed to sign out other devices" })
+        }
+    }
+)
 export const registerUser = createAsyncThunk(
     "user/register",
     async (user, thunkApi) => {

--- a/frontend/src/pages/settings/index.jsx
+++ b/frontend/src/pages/settings/index.jsx
@@ -21,6 +21,7 @@ import {
     UserX,
     BellRing,
     ShieldPlus,
+    Laptop,
 } from 'lucide-react';
 import DashboardLayout from '@/layout/DashboardLayout';
 import SettingsItem from '@/Components/ui/SettingsItem';
@@ -220,6 +221,12 @@ export default function Settings() {
                         label="Two-step verification"
                         sub={twoFactorEnabled ? "On — using an authenticator app" : "Add an extra step at login"}
                         onClick={() => router.push('/settings/two_factor')}
+                    />
+                    <SettingsItem
+                        icon={Laptop}
+                        label="Login activity"
+                        sub="Where you're signed in"
+                        onClick={() => router.push('/settings/login_activity')}
                     />
                 </div>
 

--- a/frontend/src/pages/settings/login_activity/LoginActivity.module.css
+++ b/frontend/src/pages/settings/login_activity/LoginActivity.module.css
@@ -1,0 +1,149 @@
+.container {
+    max-width: 560px;
+    margin: 0 auto;
+    padding: 24px 20px 100px;
+}
+
+.backBtn {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    background: none;
+    border: none;
+    color: var(--mt-ink2);
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    padding: 0;
+    margin-bottom: 12px;
+}
+
+.backIcon {
+    width: 18px;
+    height: 18px;
+}
+
+.titleRow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 6px;
+}
+
+.title {
+    font-family: var(--mt-font-display);
+    font-size: 28px;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    background: var(--mt-grad);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    display: inline-block;
+}
+
+.signOutOthersBtn {
+    flex-shrink: 0;
+    padding: 8px 14px;
+    border-radius: 999px;
+    border: 1px solid var(--mt-border);
+    background: var(--mt-sunken);
+    color: var(--mt-ink);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.signOutOthersBtn:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
+.sub {
+    color: var(--mt-ink2);
+    font-size: 13px;
+    margin: 0 0 20px;
+}
+
+.group {
+    background: var(--mt-surface);
+    border-radius: 16px;
+    overflow: hidden;
+    box-shadow: var(--mt-shadow);
+    border: 1px solid var(--mt-border);
+}
+
+.row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--mt-border);
+}
+
+.row:last-child {
+    border-bottom: none;
+}
+
+.deviceIcon {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: var(--mt-grad-soft);
+    color: var(--mt-accent, #0447ff);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.info {
+    flex: 1;
+    min-width: 0;
+}
+
+.info h4 {
+    font-size: 13.5px;
+    font-weight: 600;
+    color: var(--mt-ink);
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.currentTag {
+    font-size: 10.5px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--mt-accent, #0447ff);
+    background: var(--mt-grad-soft);
+    padding: 2px 8px;
+    border-radius: 999px;
+}
+
+.info p {
+    font-size: 12px;
+    color: var(--mt-ink3);
+    margin: 2px 0 0;
+}
+
+.signOutBtn {
+    flex-shrink: 0;
+    padding: 8px 14px;
+    border-radius: 999px;
+    border: 1px solid var(--mt-border);
+    background: var(--mt-sunken);
+    color: var(--mt-danger);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.signOutBtn:disabled {
+    opacity: 0.5;
+    cursor: default;
+}

--- a/frontend/src/pages/settings/login_activity/index.jsx
+++ b/frontend/src/pages/settings/login_activity/index.jsx
@@ -1,0 +1,124 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { useDispatch } from 'react-redux';
+import DashboardLayout from '@/layout/DashboardLayout';
+import BlastLoader from '@/Components/ui/BlastLoader';
+import { useToast } from '@/Components/Toast';
+import { getSessions, revokeSession, revokeOtherSessions } from '@/config/redux/action/authAction';
+import { ChevronLeft, Laptop } from 'lucide-react';
+import styles from './LoginActivity.module.css';
+
+const timeAgo = (iso) => {
+    const diffMs = Date.now() - new Date(iso).getTime();
+    const mins = Math.round(diffMs / 60000);
+    if (mins < 1) return 'Just now';
+    if (mins < 60) return `${mins}m ago`;
+    const hours = Math.round(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.round(hours / 24);
+    if (days < 30) return `${days}d ago`;
+    return new Date(iso).toLocaleDateString();
+};
+
+export default function LoginActivityPage() {
+    const router = useRouter();
+    const dispatch = useDispatch();
+    const toast = useToast();
+    const [sessions, setSessions] = useState([]);
+    const [loaded, setLoaded] = useState(false);
+    const [busyId, setBusyId] = useState(null);
+    const [busyOthers, setBusyOthers] = useState(false);
+
+    const loadSessions = async () => {
+        const result = await dispatch(getSessions());
+        if (getSessions.fulfilled.match(result)) {
+            setSessions(result.payload.sessions || []);
+        }
+        setLoaded(true);
+    };
+
+    useEffect(() => {
+        loadSessions();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const handleSignOut = async (id) => {
+        setBusyId(id);
+        const result = await dispatch(revokeSession(id));
+        setBusyId(null);
+        if (revokeSession.fulfilled.match(result)) {
+            setSessions((prev) => prev.filter((s) => s.id !== id));
+            toast.success('Signed out of that device');
+        } else {
+            toast.error(result.payload?.message || 'Failed to sign out that device');
+        }
+    };
+
+    const handleSignOutOthers = async () => {
+        if (!window.confirm("Sign out of every other device you're logged into?")) return;
+        setBusyOthers(true);
+        const result = await dispatch(revokeOtherSessions());
+        setBusyOthers(false);
+        if (revokeOtherSessions.fulfilled.match(result)) {
+            setSessions((prev) => prev.filter((s) => s.isCurrent));
+            toast.success('Signed out of all other devices');
+        } else {
+            toast.error(result.payload?.message || 'Failed to sign out other devices');
+        }
+    };
+
+    const hasOthers = sessions.some((s) => !s.isCurrent);
+
+    return (
+        <DashboardLayout>
+            <div className={styles.container}>
+                <button className={styles.backBtn} onClick={() => router.push('/settings')}>
+                    <ChevronLeft className={styles.backIcon} />
+                    Back to Settings
+                </button>
+
+                <div className={styles.titleRow}>
+                    <h1 className={styles.title}>Login activity</h1>
+                    {hasOthers && (
+                        <button className={styles.signOutOthersBtn} onClick={handleSignOutOthers} disabled={busyOthers}>
+                            {busyOthers ? 'Signing out…' : 'Sign out of all other devices'}
+                        </button>
+                    )}
+                </div>
+                <p className={styles.sub}>Where you're currently signed in to Mitrata.</p>
+
+                {!loaded ? (
+                    <div className="w-full flex items-center justify-center py-16">
+                        <BlastLoader size={48} />
+                    </div>
+                ) : (
+                    <div className={styles.group}>
+                        {sessions.map((s) => (
+                            <div className={styles.row} key={s.id}>
+                                <div className={styles.deviceIcon}>
+                                    <Laptop size={18} strokeWidth={1.8} />
+                                </div>
+                                <div className={styles.info}>
+                                    <h4>
+                                        {s.device}
+                                        {s.isCurrent && <span className={styles.currentTag}>This device</span>}
+                                    </h4>
+                                    <p>{s.ip ? `${s.ip} · ` : ''}Active {timeAgo(s.lastActiveAt)}</p>
+                                </div>
+                                {!s.isCurrent && (
+                                    <button
+                                        className={styles.signOutBtn}
+                                        onClick={() => handleSignOut(s.id)}
+                                        disabled={busyId === s.id}
+                                    >
+                                        {busyId === s.id ? 'Signing out…' : 'Sign out'}
+                                    </button>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </DashboardLayout>
+    );
+}


### PR DESCRIPTION
## Summary
- Replaces the single `refreshTokenHash` field with a `sessions` array (one entry per device). Previously logging in on a second device silently invalidated the first device's session (shared hash field), so it would get logged out on its next token refresh even though nobody logged out of it.
- New Settings > Login activity page: lists active sessions (rough device label from User-Agent, IP, last active), per-device sign-out, and a "sign out of all other devices" bulk action.
- Password reset and admin-suspend now clear every session instead of one field.
- Fixed a pre-existing bug in `deleteMyAccount` that cleared a cookie named `"refreshToken"` instead of the real per-account cookie name (found during this work, one-line fix in the same area).

## Heads up
Existing logged-in users get signed out once, on their next token refresh after this deploys — their old single-hash cookie has no matching entry in the new sessions array. Expected, self-resolves the moment they log back in.

## Test plan (done locally against real accounts)
- [x] Two concurrent logins with distinct User-Agents — confirmed BOTH stay logged in (refreshing device A no longer revokes device B, and vice versa)
- [x] Session list correctly parses device labels ("Chrome on Windows"), flags the requesting session as current
- [x] Revoke a specific non-current session — removed correctly, others untouched
- [x] "Sign out of all other devices" — leaves only the current session
- [x] `npx next build` clean, backend `node --check` clean on all touched files