### PR TITLE
Fix race condition causing cross-tab forced logout

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -27,7 +27,7 @@ import { authenticator } from "otplib";
 import QRCode from "qrcode";
 
 import { issueOtp } from "./otp.controller.js";
-import { issueSession, hashToken, refreshCookieName, refreshCookieOptions, signTwoFactorChallenge, verifyTwoFactorChallenge, describeDevice } from "../utils/session.js";
+import { issueSession, rotateSession, hashToken, refreshCookieName, refreshCookieOptions, signTwoFactorChallenge, verifyTwoFactorChallenge, describeDevice } from "../utils/session.js";
 import { sendPush } from "../utils/push.js";
 
 const googleClient = process.env.GOOGLE_CLIENT_ID ? new OAuth2Client(process.env.GOOGLE_CLIENT_ID) : null;
@@ -410,15 +410,8 @@ export const refreshAccessToken = async (req, res) => {
         const user = await User.findById(decoded.userId);
         if (!user || !user.active) return res.status(401).json({ message: "User no longer exists" });
 
-        const tokenHash = hashToken(token);
-        if (!user.sessions.some((s) => s.tokenHash === tokenHash)) {
-            return res.status(401).json({ message: "Refresh token has been revoked" });
-        }
-        // Rotating: this device's old session entry is replaced by the fresh
-        // one issueSession appends below, every other device's is untouched.
-        user.sessions = user.sessions.filter((s) => s.tokenHash !== tokenHash);
-
-        const accessToken = await issueSession(res, user, req); // rotate refresh token too
+        const accessToken = await rotateSession(res, user, hashToken(token), req);
+        if (!accessToken) return res.status(401).json({ message: "Refresh token has been revoked" });
         return res.json({ token: accessToken });
     } catch (error) {
         return res.status(401).json({ message: "Refresh token invalid or expired, please login again" });
@@ -469,14 +462,12 @@ export const switchAccount = async (req, res) => {
             res.clearCookie(cookieName, refreshCookieOptions());
             return res.status(401).json({ message: "Account unavailable", needsLogin: true });
         }
-        const tokenHash = hashToken(token);
-        if (!user.sessions.some((s) => s.tokenHash === tokenHash)) {
+
+        const accessToken = await rotateSession(res, user, hashToken(token), req);
+        if (!accessToken) {
             res.clearCookie(cookieName, refreshCookieOptions());
             return res.status(401).json({ message: "Session expired, please log in again", needsLogin: true });
         }
-        user.sessions = user.sessions.filter((s) => s.tokenHash !== tokenHash);
-
-        const accessToken = await issueSession(res, user, req);
         return res.json({ token: accessToken });
     } catch (error) {
         return res.status(500).json({ message: error.message });

--- a/backend/utils/session.js
+++ b/backend/utils/session.js
@@ -99,6 +99,43 @@ export const issueSession = async (res, user, req = null) => {
     return accessToken;
 };
 
+// Rotates one existing session in place, keyed by its OLD token hash, via a
+// single atomic findOneAndUpdate (positional operator) instead of the
+// read-array/filter/push/save round trip issueSession does. That mattered
+// because refreshCookieName is per-USER, not per-tab — every open tab of the
+// same account on the same browser shares one cookie, so when two tabs' 15m
+// access tokens expire around the same moment, both fire /auth/refresh with
+// the IDENTICAL cookie value at nearly the same time. A read-modify-write
+// there is a lost-update race: whichever save() landed second could silently
+// overwrite the winner's rotation, leaving BOTH tabs' cookies invalid and
+// forcing a real logout — which is exactly the "logging in kicks everyone
+// else out" bug this was mistaken for. Here, only one concurrent call can
+// match `sessions.tokenHash: oldTokenHash` (Mongo serializes writes to a
+// single document); the loser just gets `null` back and no session is lost
+// or corrupted, it was already rotated by the winner.
+export const rotateSession = async (res, user, oldTokenHash, req = null) => {
+    const accessToken = signAccessToken(user._id);
+    const refreshToken = signRefreshToken(user._id);
+
+    const Model = user.constructor;
+    const updated = await Model.findOneAndUpdate(
+        { _id: user._id, "sessions.tokenHash": oldTokenHash },
+        {
+            $set: {
+                "sessions.$.tokenHash": hashToken(refreshToken),
+                "sessions.$.lastActiveAt": new Date(),
+                "sessions.$.userAgent": req?.headers?.["user-agent"] || "",
+                "sessions.$.ip": req?.ip || "",
+            }
+        },
+        { new: true }
+    );
+    if (!updated) return null; // another request already rotated this exact session
+
+    setRefreshCookie(res, refreshToken, user._id);
+    return accessToken;
+};
+
 // Bridges login's password step to the 2FA code step without a full session:
 // short-lived on purpose (5m is plenty to type a 6-digit code), and its own
 // `type` claim so it can never be replayed as an access token even if JWT_SECRET

--- a/frontend/src/config/index.jsx
+++ b/frontend/src/config/index.jsx
@@ -67,6 +67,7 @@ clientServer.interceptors.response.use(
             typeof window !== "undefined"
         ) {
             originalRequest._retried = true;
+            const tokenBeforeRefresh = localStorage.getItem("token");
             try {
                 if (!refreshPromise) {
                     const expiringToken = localStorage.getItem("token");
@@ -78,6 +79,19 @@ clientServer.interceptors.response.use(
                 originalRequest.headers.Authorization = `Bearer ${data.token}`;
                 return clientServer(originalRequest);
             } catch (refreshError) {
+                // `refreshPromise` only dedupes concurrent refreshes within THIS
+                // tab — every open tab of the same account shares one refresh
+                // cookie, so two tabs' access tokens expiring around the same
+                // moment can both hit /auth/refresh at once. The backend lets
+                // only one rotate (see rotateSession); this tab is the loser,
+                // but localStorage is shared across tabs, so if the winner's
+                // write already landed, just use it instead of forcing a
+                // logout over what was really just a lost race, not a revoke.
+                const currentToken = localStorage.getItem("token");
+                if (currentToken && currentToken !== tokenBeforeRefresh) {
+                    originalRequest.headers.Authorization = `Bearer ${currentToken}`;
+                    return clientServer(originalRequest);
+                }
                 goToLogin();
                 return Promise.reject(refreshError);
             }


### PR DESCRIPTION
## Root cause
Every open tab of the same logged-in account, on the same browser, shares one refresh cookie (`rt_<userId>` is per-account, not per-tab). When two tabs' 15-minute access tokens expired around the same moment, both fired `/auth/refresh` with the identical cookie. The rotation logic (read sessions array, filter out old entry, push new one, save) was a classic lost-update race — whichever `save()` landed second could silently overwrite the winner's rotation, leaving BOTH tabs' cookies invalid. This read exactly like "logging in signs me out everywhere," but it was actually the same login racing itself across tabs, not a genuinely separate device kicking anyone.

## Fix
- Backend: `rotateSession` (new, in `utils/session.js`) does the rotation as one atomic `findOneAndUpdate` keyed on the OLD token hash. Only one concurrent call can match and win — the loser gets a clean 401 instead of corrupting the array. Used by both `refreshAccessToken` and `switchAccount`.
- Frontend: the axios response interceptor, before forcing a logout on a failed refresh, checks whether `localStorage`'s token already changed (meaning another tab — sharing that same localStorage — already won the race) and retries against that instead of logging out.

## Test plan
- [x] 8 concurrent `/auth/refresh` calls sharing one cookie (guaranteed-fresh server process, confirmed via `ps`): exactly 1 returns 200, the other 7 return a clean "revoked" 401, DB shows exactly one new session entry — no duplication or corruption
- [x] `npx next build` clean, backend `node --check` clean