### PR TITLE
Recognize mobile app's User-Agent in login activity

### DIFF
--- a/backend/utils/session.js
+++ b/backend/utils/session.js
@@ -26,6 +26,14 @@ const MAX_SESSIONS_PER_USER = 10;
 // on Windows" from "Safari on iPhone" at a glance.
 export const describeDevice = (userAgent = "") => {
     const ua = userAgent || "";
+
+    // The Flutter app identifies itself with this marker (see mobile's
+    // ApiClient request interceptor) instead of dart:io's generic default —
+    // callers of this function never need to know mobile exists as a
+    // separate case, it's just a nicer label for the same session list.
+    const mobileMatch = ua.match(/MitrataMobile\/[\d.]+ \((\w+)\)/);
+    if (mobileMatch) return `Mitrata App on ${mobileMatch[1]}`;
+
     let os = "Unknown OS";
     if (/iPhone|iPad/.test(ua)) os = "iOS";
     else if (/Android/.test(ua)) os = "Android";


### PR DESCRIPTION
## Summary
Small follow-up to the Login Activity feature: the new Flutter mobile app now has real multi-device session support (persistent refresh-token cookie jar, 401-retry, its own Login Activity screen). It identifies itself with a `MitrataMobile/x.x (Platform)` User-Agent marker; `describeDevice` now recognizes it and labels those sessions "Mitrata App on iOS/Android" instead of the generic fallback.

## Test plan
- [x] `node --check` clean