### PR TITLE
Fix cold-start forced logout and stale-socket offline presence

### DIFF
--- a/frontend/src/Components/NotificationProvider/index.jsx
+++ b/frontend/src/Components/NotificationProvider/index.jsx
@@ -1,6 +1,6 @@
     import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
 import { io } from 'socket.io-client';
-import { Base_Url } from '@/config';
+import { Base_Url, clientServer, decodeJwtUserId } from '@/config';
 import { useRouter } from 'next/router';
 import { useSelector } from 'react-redux';
 import axios from 'axios';
@@ -147,7 +147,38 @@ export function NotificationProvider({ children }) {
         const socket = io(Base_Url, {
             transports: ['websocket'],
             autoConnect: true,
-            auth: { token }
+            // A function, not a static object — access tokens are 15-minute
+            // JWTs, and this used to snapshot the token once at connect time.
+            // REST calls silently refresh a stale token via the axios
+            // interceptor, but nothing told the socket, so any reconnection
+            // (network blip, phone backgrounding, laptop sleep — all common)
+            // retried the handshake with the SAME expired token, got rejected
+            // server-side (io.use's jwt.verify), and never recovered: the
+            // user kept using the app fine over REST while their socket sat
+            // dead, showing them as permanently "offline" to everyone else.
+            // socket.io-client calls a function `auth` fresh before every
+            // (re)connection attempt, so this always sends whatever's
+            // current in localStorage.
+            auth: (cb) => cb({ token: localStorage.getItem('token') }),
+        });
+
+        // Belt-and-suspenders for the rarer case where NO REST call happened
+        // during the staleness window (e.g. a backgrounded tab with only the
+        // socket active) — refresh the token once and let socket.io's own
+        // reconnection backoff pick it up on the next attempt.
+        socket.on('connect_error', async (err) => {
+            if (!/token|auth/i.test(err.message || '')) return;
+            try {
+                const currentToken = localStorage.getItem('token');
+                const userId = currentToken ? decodeJwtUserId(currentToken) : null;
+                if (!userId) return;
+                const { data } = await clientServer.post('/auth/refresh', { userId });
+                localStorage.setItem('token', data.token);
+            } catch {
+                // Refresh itself failed (genuinely logged out, or backend
+                // still cold-starting) — socket.io keeps retrying its own
+                // backoff regardless; nothing more to do here.
+            }
         });
 
         socketRef.current = socket;

--- a/frontend/src/config/index.jsx
+++ b/frontend/src/config/index.jsx
@@ -26,6 +26,15 @@ export const clientServer = axios.create({
     withCredentials: true, // send/receive the httpOnly refresh-token cookie
 });
 
+// The Render free-tier backend spins down after inactivity and can take
+// 30-90s to cold-start back up — well past the normal 15s timeout above.
+// Someone closing the browser and returning later is exactly the case that
+// hits a cold start on their very first request. The refresh call gets its
+// own longer timeout so that's survivable instead of reading as a dead
+// session (see the 401-interceptor below for why the timeout length alone
+// isn't the whole fix).
+const REFRESH_TIMEOUT_MS = 60000;
+
 // Auto-attach JWT token to all requests
 clientServer.interceptors.request.use((config) => {
     const token = typeof window !== "undefined" ? localStorage.getItem("token") : null;
@@ -72,7 +81,9 @@ clientServer.interceptors.response.use(
                 if (!refreshPromise) {
                     const expiringToken = localStorage.getItem("token");
                     const userId = expiringToken ? decodeJwtUserId(expiringToken) : null;
-                    refreshPromise = clientServer.post('/auth/refresh', { userId }).finally(() => { refreshPromise = null; });
+                    refreshPromise = clientServer
+                        .post('/auth/refresh', { userId }, { timeout: REFRESH_TIMEOUT_MS })
+                        .finally(() => { refreshPromise = null; });
                 }
                 const { data } = await refreshPromise;
                 localStorage.setItem("token", data.token);
@@ -92,7 +103,21 @@ clientServer.interceptors.response.use(
                     originalRequest.headers.Authorization = `Bearer ${currentToken}`;
                     return clientServer(originalRequest);
                 }
-                goToLogin();
+
+                // Only a definitive 401/403 FROM THE REFRESH CALL means the
+                // session is actually gone (cookie missing/revoked/expired).
+                // Anything else — a timeout, a network error, a 5xx — means
+                // the request never got a real answer (a cold-starting Render
+                // backend routinely takes longer than any reasonable timeout
+                // right after a period of inactivity, which is exactly when
+                // someone re-opens a closed browser). Treating that the same
+                // as "revoked" was logging people out of perfectly valid
+                // sessions. Leave the token alone and let the next request
+                // retry — by then the backend answers normally again.
+                const status = refreshError.response?.status;
+                if (status === 401 || status === 403) {
+                    goToLogin();
+                }
                 return Promise.reject(refreshError);
             }
         }


### PR DESCRIPTION
## Summary
Two related real-time reliability fixes:

1. **Persistent login was still failing.** The refresh-retry logic treated ANY failure of `/auth/refresh` as a revoked session — including a network timeout or the Render free-tier backend cold-starting after inactivity, which routinely takes longer than a normal request timeout right after a period of inactivity (exactly when someone reopens a closed browser). Now only a genuine 401/403 from that specific call forces logout; a timeout/network/5xx just fails the one request and leaves the token alone, so the very next action retries once the backend answers normally again. The refresh call also gets a 60s timeout instead of the default 15s.

2. **Online presence went stale after reconnects.** The notification socket's `auth` was a static token snapshot taken once at connect. Access tokens are 15-minute JWTs — REST calls silently refresh a stale one via the axios interceptor, but nothing told the socket, so any reconnection (network blip, phone backgrounding, laptop sleep) retried the handshake with the same expired token, got rejected server-side, and never recovered. The user kept using the app fine over REST while their socket sat dead, showing as permanently offline to everyone else — including mid-call. `auth` is now a function (the documented socket.io-client pattern for exactly this) called fresh before every (re)connection attempt, plus a `connect_error` handler that proactively refreshes the token for the rarer case where no REST call happened during the staleness window.

## Test plan
- [x] Isolated branch-logic assertions: 401/403 still force logout, timeout/network-error/5xx do not
- [x] Confirmed `auth: (cb) => cb({...})` matches socket.io-client's own documented dynamic-auth pattern (checked its type definitions)
- [x] `npx next build` clean
- [ ] Manually verify in production: close browser, wait a while (long enough for Render to cold-start), reopen — should stay logged in. Two users calling each other after one reconnects (e.g. phone lock/unlock) should show correct online status.