### PR TITLE
Fix quick-switch dead-end for Google accounts + GSI double-init bug

### DIFF
--- a/frontend/src/Components/ui/GoogleLoginButton.jsx
+++ b/frontend/src/Components/ui/GoogleLoginButton.jsx
@@ -3,23 +3,42 @@ import { useEffect, useRef } from 'react';
 const CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
 const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
 
+// GSI's own client is a global singleton — calling initialize() again from a
+// second mount of this component (chooser → password fallback → back, or
+// just two instances on the page at once) doesn't reset anything, it just
+// logs "called multiple times... only the last initialized instance will be
+// used" and re-points that singleton at whichever <div> called it last. One
+// real initialize() call, tracked here across every mount of this component.
+let gsiInitialized = false;
+
 export default function GoogleLoginButton() {
   const buttonRef = useRef(null);
 
   useEffect(() => {
     if (!CLIENT_ID) return;
+    let cancelled = false;
 
     const renderButton = () => {
-      window.google.accounts.id.initialize({
-        client_id: CLIENT_ID,
-        // The classic popup+iframe handshake this library used to rely on
-        // gets silently blocked by Safari's Intelligent Tracking Prevention
-        // and Edge's Tracking Prevention ("Failed to open popup window").
-        // ux_mode:"redirect" is a real top-level navigation instead, so it
-        // isn't affected by popup blockers or third-party-cookie policies.
-        ux_mode: 'redirect',
-        login_uri: `${BACKEND_URL}/api/auth/google/callback`,
-      });
+      // The script's onload (or the "already loaded" branch below) can fire
+      // after this instance has already unmounted (e.g. the chooser
+      // fell through to this button and the user navigated away before the
+      // script finished loading) — rendering into a detached buttonRef then
+      // throws GSI's own "no parent or options set" error.
+      if (cancelled || !buttonRef.current) return;
+
+      if (!gsiInitialized) {
+        window.google.accounts.id.initialize({
+          client_id: CLIENT_ID,
+          // The classic popup+iframe handshake this library used to rely on
+          // gets silently blocked by Safari's Intelligent Tracking Prevention
+          // and Edge's Tracking Prevention ("Failed to open popup window").
+          // ux_mode:"redirect" is a real top-level navigation instead, so it
+          // isn't affected by popup blockers or third-party-cookie policies.
+          ux_mode: 'redirect',
+          login_uri: `${BACKEND_URL}/api/auth/google/callback`,
+        });
+        gsiInitialized = true;
+      }
       window.google.accounts.id.renderButton(buttonRef.current, {
         theme: 'outline',
         size: 'large',
@@ -30,14 +49,17 @@ export default function GoogleLoginButton() {
 
     if (window.google?.accounts?.id) {
       renderButton();
-      return;
+    } else {
+      const script = document.createElement('script');
+      script.src = 'https://accounts.google.com/gsi/client';
+      script.async = true;
+      script.onload = renderButton;
+      document.body.appendChild(script);
     }
 
-    const script = document.createElement('script');
-    script.src = 'https://accounts.google.com/gsi/client';
-    script.async = true;
-    script.onload = renderButton;
-    document.body.appendChild(script);
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   if (!CLIENT_ID) {

--- a/frontend/src/config/savedAccounts.js
+++ b/frontend/src/config/savedAccounts.js
@@ -24,6 +24,11 @@ export const rememberAccount = (user) => {
         name: user.name,
         username: user.username,
         profilePicture: user.profilePicture,
+        // Whether this account signed up/links via Google — a Google-only
+        // account has no password at all, so if the saved-session cookie
+        // ever needs re-auth, the fallback must not be a password field it's
+        // literally impossible to fill in.
+        googleId: user.googleId || null,
     };
     const existing = getSavedAccounts().filter((a) => a.email !== entry.email);
     const next = [entry, ...existing].slice(0, MAX_ACCOUNTS);

--- a/frontend/src/pages/login/index.jsx
+++ b/frontend/src/pages/login/index.jsx
@@ -28,6 +28,11 @@ function LoginComponent() {
   const [savedAccounts, setSavedAccounts] = useState([]);
   const [showChooser, setShowChooser] = useState(false);
   const [switchingAccountId, setSwitchingAccountId] = useState(null);
+  // Set when a saved Google-linked account's quick-switch session expired —
+  // that account has no password at all, so the normal email/password form
+  // is a dead end for it; this instead surfaces just the Google button,
+  // pre-aimed at the same account, one click instead of a form nobody can fill in.
+  const [googleReauthAccount, setGoogleReauthAccount] = useState(null);
 
   const [email, setEmail] = useState("");
   const [name, setName] = useState("");
@@ -101,6 +106,12 @@ function LoginComponent() {
       // Full reload, not a client-side push — see the identical note in
       // DashboardLayout's handleSwitchAccount for why.
       window.location.href = '/dashboard';
+    } else if (acc.googleId) {
+      // No password exists for this account at all — dropping into the
+      // email/password form here was a dead end that just looked like
+      // "asking for a password" with nothing the user could type.
+      setShowChooser(false);
+      setGoogleReauthAccount(acc);
     } else {
       // That account's session actually expired — fall through to a normal,
       // prefilled sign-in instead of leaving them stuck.
@@ -196,7 +207,7 @@ function LoginComponent() {
         <div className={styles.cardContainer}>
           <div className={styles.cardContainer_left}>
             <p className={styles.cardHeading}>
-              {authState.requires2FA ? 'Two-step verification' : verifyingEmail ? 'Verify your email' : showChooser ? 'Choose an account' : (userLoginMethod ? 'SignIn' : 'Signup')}
+              {googleReauthAccount ? 'Sign in again' : authState.requires2FA ? 'Two-step verification' : verifyingEmail ? 'Verify your email' : showChooser ? 'Choose an account' : (userLoginMethod ? 'SignIn' : 'Signup')}
             </p>
 
             {/* General API Status Messages */}
@@ -218,7 +229,30 @@ function LoginComponent() {
                </div>
             )}
 
-            {authState.requires2FA ? (
+            {googleReauthAccount ? (
+              <div className={styles.inputContainer} style={{ textAlign: 'center' }}>
+                <img
+                  src={googleReauthAccount.profilePicture || '/default-avatar.svg'}
+                  alt=""
+                  style={{ width: 56, height: 56, borderRadius: '50%', objectFit: 'cover', margin: '0 auto 12px' }}
+                />
+                <p className="text-sm mb-1" style={{ color: 'var(--mt-ink)', fontWeight: 600 }}>
+                  {googleReauthAccount.name}
+                </p>
+                <p className="text-sm mb-4" style={{ color: 'var(--mt-ink2)' }}>
+                  Your saved session expired — sign in again with Google to continue as {googleReauthAccount.email}.
+                </p>
+                <GoogleLoginButton />
+                <button
+                  type="button"
+                  onClick={() => { setGoogleReauthAccount(null); setShowChooser(savedAccounts.length > 0); }}
+                  className="text-sm mt-3"
+                  style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--mt-ink3)' }}
+                >
+                  Use a different account
+                </button>
+              </div>
+            ) : authState.requires2FA ? (
               <div className={styles.inputContainer}>
                 <p className="text-sm mb-3" style={{ color: 'var(--mt-ink2)' }}>
                   Enter the 6-digit code from your authenticator app, or one of your backup codes.
@@ -380,7 +414,7 @@ function LoginComponent() {
             <img src="/brand/orb-violet.png" alt="" className={styles.rightOrb} />
             <div className={styles.rightContent}>
               <span className={styles.rightLogo} role="img" aria-label="Mitrata" />
-              {!showChooser && !verifyingEmail && !authState.requires2FA && (
+              {!showChooser && !verifyingEmail && !authState.requires2FA && !googleReauthAccount && (
                 <>
                   <span>{userLoginMethod ? 'Create an account? ' : 'Already have an account? '}</span>
                   <span


### PR DESCRIPTION
## Summary
- Saved accounts (quick-switch chooser on `/login`) now remember whether they're Google-linked. When a saved account's switch-account session has expired, Google-linked accounts get the Google button directly instead of falling into an email/password form they have no password to fill in (Google-only accounts never set one).
- Fixed a real bug surfaced in the process: `GoogleLoginButton` called `google.accounts.id.initialize()` unconditionally on every mount (GSI's own console warned "called multiple times... only the last initialized instance will be used") and could attempt to render into an already-unmounted button ref ("no parent or options set"). Both guarded now.

## Context on the reported issue
The specific 401 on `/api/auth/switch-account` for an existing account is very likely one-time fallout from today's earlier session-model migration (single `refreshTokenHash` → per-device `sessions` array) — any cookie issued before that deploy has no matching entry in the new model and will 401 exactly once, self-resolving after one full fresh login. The actual, recurring bug was the broken fallback UX this PR fixes: a Google-only account had no way to recover from that 401 except retyping a password it doesn't have.

## Test plan
- [x] `npx next build` clean
- [ ] Manually verify: expire/clear a Google-linked account's switch-account cookie, click it in the chooser, confirm the Google button appears instead of a password field