### PR TITLE
Fix Google sign-in never persisting a session

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -27,7 +27,7 @@ import { authenticator } from "otplib";
 import QRCode from "qrcode";
 
 import { issueOtp } from "./otp.controller.js";
-import { issueSession, rotateSession, hashToken, refreshCookieName, refreshCookieOptions, signTwoFactorChallenge, verifyTwoFactorChallenge, describeDevice } from "../utils/session.js";
+import { issueSession, rotateSession, hashToken, refreshCookieName, refreshCookieOptions, signTwoFactorChallenge, verifyTwoFactorChallenge, describeDevice, signGoogleSessionCode, verifyGoogleSessionCode } from "../utils/session.js";
 import { sendPush } from "../utils/push.js";
 
 const googleClient = process.env.GOOGLE_CLIENT_ID ? new OAuth2Client(process.env.GOOGLE_CLIENT_ID) : null;
@@ -388,11 +388,42 @@ export const googleLoginCallback = async (req, res) => {
     const failUrl = `${process.env.FRONTEND_URL}/login?googleError=1`;
     try {
         const user = await verifyAndUpsertGoogleUser(req.body.credential);
-        const accessToken = await issueSession(res, user, req);
-        return res.redirect(`${process.env.FRONTEND_URL}/login?googleToken=${accessToken}`);
+        // No issueSession/cookie here — this response is to a genuine
+        // cross-origin top-level navigation (see signGoogleSessionCode's
+        // comment for why), so any cookie set on it would be scoped to the
+        // wrong origin. The frontend exchanges this one-time code for a real
+        // session via completeGoogleLogin below, over a normal same-origin
+        // proxied request instead.
+        const code = signGoogleSessionCode(user._id);
+        return res.redirect(`${process.env.FRONTEND_URL}/login?googleSessionCode=${code}`);
     } catch (error) {
         console.error("Google login callback error:", error.message);
         return res.redirect(failUrl);
+    }
+};
+
+// Completes googleLoginCallback's redirect hop — called by the frontend as a
+// normal proxied POST (same-origin from the browser's point of view), so the
+// session cookie this issues actually lands on the frontend's own origin.
+export const completeGoogleLogin = async (req, res) => {
+    try {
+        const { code } = req.body || {};
+        if (!code) return res.status(400).json({ message: "Code is required" });
+
+        let userId;
+        try {
+            userId = verifyGoogleSessionCode(code);
+        } catch {
+            return res.status(401).json({ message: "Sign-in link expired, please try again" });
+        }
+
+        const user = await User.findById(userId);
+        if (!user || !user.active) return res.status(401).json({ message: "Account unavailable" });
+
+        const accessToken = await issueSession(res, user, req);
+        return res.json({ token: accessToken });
+    } catch (error) {
+        return res.status(500).json({ message: error.message });
     }
 };
 

--- a/backend/routes/user.routes.js
+++ b/backend/routes/user.routes.js
@@ -1,6 +1,6 @@
 
 import multer from "multer";
-import { acceptConnectionRequest, downloadProfile, findSearchUser, getAllUserBasedOnUsername, getMyConnectionRequest, getUserAndProfile, login, logout, register, sendconnectionrequest, updateProfileData, updateUserProfile, updateAccountSettings, uploadCoverPhoto, uploadImage, uploadProfilePicture, whatAreMyConnection, searchUsers, getSuggestions, googleLogin, googleLoginCallback, refreshAccessToken, deleteMyAccount, switchAccount, registerFcmToken, unregisterFcmToken, blockUser, unblockUser, getBlockedUsers, verifyTwoFactorLogin, getTwoFactorStatus, setupTwoFactor, verifyTwoFactorSetup, disableTwoFactor, getSessions, revokeSession, revokeOtherSessions } from "../controllers/user.controller.js";
+import { acceptConnectionRequest, downloadProfile, findSearchUser, getAllUserBasedOnUsername, getMyConnectionRequest, getUserAndProfile, login, logout, register, sendconnectionrequest, updateProfileData, updateUserProfile, updateAccountSettings, uploadCoverPhoto, uploadImage, uploadProfilePicture, whatAreMyConnection, searchUsers, getSuggestions, googleLogin, googleLoginCallback, refreshAccessToken, deleteMyAccount, switchAccount, registerFcmToken, unregisterFcmToken, blockUser, unblockUser, getBlockedUsers, verifyTwoFactorLogin, getTwoFactorStatus, setupTwoFactor, verifyTwoFactorSetup, disableTwoFactor, getSessions, revokeSession, revokeOtherSessions, completeGoogleLogin } from "../controllers/user.controller.js";
 import { sendOtp, verifyOtp, resendOtp, resetPassword } from "../controllers/otp.controller.js";
 import { createReport } from "../controllers/admin.controller.js";
 import { Router } from "express"
@@ -17,6 +17,7 @@ router.route('/login').post(login);
 router.route('/logout').post(logout);
 router.route('/auth/google').post(googleLogin);
 router.route('/auth/google/callback').post(googleLoginCallback);
+router.route('/auth/google/complete').post(completeGoogleLogin);
 router.route('/auth/refresh').post(refreshAccessToken);
 router.route('/auth/send-otp').post(sendOtp);
 router.route('/auth/verify-otp').post(verifyOtp);

--- a/backend/utils/session.js
+++ b/backend/utils/session.js
@@ -159,4 +159,25 @@ export const verifyTwoFactorChallenge = (token) => {
     return decoded.userId;
 };
 
+// Google's redirect sign-in flow is a genuine top-level browser navigation
+// straight to this backend's own origin (GSI POSTs to login_uri directly —
+// there's no way to route that hop through the frontend's same-origin proxy
+// the way every other request goes). A cookie set on THAT response would be
+// scoped to the backend's own host, not the frontend's — useless for every
+// later request, which all go through the proxy and only ever carry
+// frontend-scoped cookies. So googleLoginCallback doesn't set a cookie at
+// all; it hands back this one-time code instead, and the frontend exchanges
+// it via a normal proxied POST (see completeGoogleLogin), which DOES land
+// the cookie on the right origin, exactly like every other login path.
+const GOOGLE_SESSION_CODE_TTL = "2m";
+
+export const signGoogleSessionCode = (userId) =>
+    jwt.sign({ userId, type: "google_session_code" }, process.env.JWT_SECRET, { expiresIn: GOOGLE_SESSION_CODE_TTL });
+
+export const verifyGoogleSessionCode = (token) => {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    if (decoded.type !== "google_session_code") throw new Error("Invalid session code");
+    return decoded.userId;
+};
+
 export { hashToken };

--- a/frontend/src/config/redux/action/authAction/index.js
+++ b/frontend/src/config/redux/action/authAction/index.js
@@ -59,6 +59,25 @@ export const verifyTwoFactorLogin = createAsyncThunk(
     }
 )
 
+// Second half of the Google redirect flow — googleLoginCallback (a genuine
+// cross-origin top-level navigation straight to the backend) can't set a
+// same-origin session cookie itself, so it hands back a one-time code
+// instead. This exchanges it via a normal proxied request, which DOES land
+// the refresh cookie on the frontend's own origin like every other login path.
+export const completeGoogleLogin = createAsyncThunk(
+    "user/completeGoogleLogin",
+    async (code, thunkApi) => {
+        try {
+            const response = await clientServer.post('/auth/google/complete', { code });
+            if (!response.data.token) return thunkApi.rejectWithValue({ message: "token not provided" });
+            startNewSession(response.data.token);
+            return thunkApi.fulfillWithValue(response.data.token)
+        } catch (error) {
+            return thunkApi.rejectWithValue(error.response?.data || { message: "Google sign-in failed" })
+        }
+    }
+)
+
 export const getTwoFactorStatus = createAsyncThunk(
     "user/getTwoFactorStatus",
     async (_arg, thunkApi) => {

--- a/frontend/src/config/redux/reducer/authReducer/index.js
+++ b/frontend/src/config/redux/reducer/authReducer/index.js
@@ -1,5 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { getAboutUser, loginUser, registerUser, getAllUser, getConnectionRequest, getMyConnectionRequests, acceptConnectionRequest, downloadResume, updateUserProfile, updateAccountSettings, blockUser, unblockUser, getBlockedUsers, logout, verifyOtp, resendOtp, sendOtp, resetPasswordAction, deleteAccount, switchAccountAction, verifyTwoFactorLogin, getTwoFactorStatus } from "../../action/authAction/index";
+import { getAboutUser, loginUser, registerUser, getAllUser, getConnectionRequest, getMyConnectionRequests, acceptConnectionRequest, downloadResume, updateUserProfile, updateAccountSettings, blockUser, unblockUser, getBlockedUsers, logout, verifyOtp, resendOtp, sendOtp, resetPasswordAction, deleteAccount, switchAccountAction, verifyTwoFactorLogin, getTwoFactorStatus, completeGoogleLogin } from "../../action/authAction/index";
 import { rememberAccount } from "../../../savedAccounts";
 
 
@@ -83,6 +83,23 @@ const authSlice = createSlice({
                 state.requires2FA = false
                 state.twoFactorChallengeToken = null
                 state.message = "login sucessfully"
+            })
+            .addCase(completeGoogleLogin.pending, (state) => {
+                state.isLoading = true
+                state.isError = false
+            })
+            .addCase(completeGoogleLogin.fulfilled, (state) => {
+                state.isLoading = false
+                state.isSuccess = true
+                state.isError = false
+                state.loggedIn = true
+                state.isTokenThere = true
+                state.message = "login sucessfully"
+            })
+            .addCase(completeGoogleLogin.rejected, (state, action) => {
+                state.isLoading = false
+                state.isError = true
+                state.message = action.payload?.message || 'Google sign-in failed';
             })
             .addCase(verifyTwoFactorLogin.rejected, (state, action) => {
                 state.isLoading = false

--- a/frontend/src/pages/login/index.jsx
+++ b/frontend/src/pages/login/index.jsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router'
 import React, { useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import styles from './styles.module.css'
-import { loginUser, registerUser, verifyOtp, resendOtp, switchAccountAction, getAboutUser, verifyTwoFactorLogin } from '@/config/redux/action/authAction'
+import { loginUser, registerUser, verifyOtp, resendOtp, switchAccountAction, getAboutUser, verifyTwoFactorLogin, completeGoogleLogin } from '@/config/redux/action/authAction'
 import { emptyMessage } from '@/config/redux/reducer/authReducer'
 import { getSavedAccounts } from '@/config/savedAccounts'
 import Button from '@/Components/ui/Button'
@@ -56,20 +56,30 @@ function LoginComponent() {
 
   // Google sign-in now completes via a full-page redirect (see
   // GoogleLoginButton) rather than a popup, so the result lands here as
-  // query params instead of a JS callback.
+  // query params instead of a JS callback. That redirect is a genuine
+  // cross-origin hop straight to the backend, so it can't hand back a
+  // session cookie scoped to this frontend's own origin (see
+  // completeGoogleLogin's comment) — only a one-time code, exchanged here
+  // over a normal proxied request that DOES land the cookie correctly.
   const [googleAuthError, setGoogleAuthError] = useState(false);
   useEffect(() => {
     if (!router.isReady) return;
-    if (router.query.googleToken) {
-      localStorage.setItem("token", String(router.query.googleToken));
-      localStorage.removeItem("recentSearches");
-      dispatch(getAboutUser());
-      router.replace('/dashboard');
+    if (router.query.googleSessionCode) {
+      const code = String(router.query.googleSessionCode);
+      router.replace('/login', undefined, { shallow: true });
+      dispatch(completeGoogleLogin(code)).then((result) => {
+        if (completeGoogleLogin.fulfilled.match(result)) {
+          dispatch(getAboutUser());
+          router.push('/dashboard');
+        } else {
+          setGoogleAuthError(true);
+        }
+      });
     } else if (router.query.googleError) {
       setGoogleAuthError(true);
       router.replace('/login', undefined, { shallow: true });
     }
-  }, [router.isReady, router.query.googleToken, router.query.googleError]);
+  }, [router.isReady, router.query.googleSessionCode, router.query.googleError]);
 
   useEffect(() => {
     const token = localStorage.getItem("token");


### PR DESCRIPTION
## Root cause
Google's redirect sign-in is a genuine top-level browser navigation straight to the backend's own origin (\`mitrata.onrender.com\`) — GSI POSTs to \`login_uri\` directly, that hop can't go through the frontend's same-origin proxy the way every other request does. The refresh cookie \`issueSession\` set on that response was scoped to the backend's own host, not the frontend's (\`mitrata.vercel.app\`) — every later request goes through the proxy and only ever carries frontend-scoped cookies, so **that cookie was permanently unusable from the moment it was set.** This explains why re-doing Google sign-in never fixed persistent login for a Google-linked account: every single Google login created a session that could never actually be used again.

Email/password login never had this problem — it already goes end-to-end through the proxy.

## Fix
\`googleLoginCallback\` no longer sets a cookie on the cross-origin hop. It hands back a short-lived (2 min), single-purpose one-time code instead. The frontend exchanges that code via a normal proxied POST to the new \`/auth/google/complete\`, which issues the real session from a request that actually went through the proxy — landing the cookie on the right origin, same as every other login path.

## Test plan
- [x] Minted a real session code locally, exchanged it through the actual frontend dev-server proxy — cookie + token both issued correctly, and that cookie worked for a subsequent proxied \`/auth/refresh\` call
- [x] \`npx next build\` clean, backend \`node --check\` clean on all touched files
- [ ] Manually verify in production: sign in with Google, close the browser, come back later — should stay logged in this time