### PR TITLE
Fix Google account avatars not rendering (blocked by browser tracking prevention)

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -316,6 +316,25 @@ export const revokeOtherSessions = async (req, res) => {
 // Edge's Tracking Prevention both block the popup+iframe handshake GSI's
 // classic ux_mode:"popup" button relies on, so browsers that can't complete
 // that handshake fall back to a full-page redirect instead.
+// Google's own avatar CDN (lh3.googleusercontent.com/accounts.google.com)
+// is on several ad/privacy-blocker filter lists and gets blocked outright by
+// browser tracking prevention in third-party contexts — storing that URL
+// directly meant a Google-signed-in user's avatar could silently fail to
+// render everywhere in the app, on any browser/extension that blocks it.
+// Re-hosting through our own Cloudinary once removes that dependency
+// entirely; cloudinary.uploader.upload accepts a remote URL directly; it
+// fetches server-side, no need to download the bytes ourselves here.
+const rehostGoogleAvatar = async (pictureUrl) => {
+    if (!pictureUrl) return null;
+    try {
+        const result = await cloudinary.uploader.upload(pictureUrl, { folder: "mitrata_social" });
+        return result.secure_url;
+    } catch (err) {
+        console.error("Failed to re-host Google avatar:", err.message);
+        return pictureUrl; // fall back to the original — better than nothing
+    }
+};
+
 const verifyAndUpsertGoogleUser = async (idToken) => {
     if (!googleClient) {
         const err = new Error("Google login is not configured on this server");
@@ -348,7 +367,7 @@ const verifyAndUpsertGoogleUser = async (idToken) => {
             email: payload.email,
             username,
             googleId: payload.sub,
-            profilePicture: payload.picture || undefined,
+            profilePicture: (await rehostGoogleAvatar(payload.picture)) || undefined,
             // Google already verified this address — no OTP step needed.
             emailVerified: true
         });
@@ -358,10 +377,18 @@ const verifyAndUpsertGoogleUser = async (idToken) => {
         const err = new Error("This account has been suspended");
         err.status = 403;
         throw err;
-    } else if (!user.googleId || !user.emailVerified) {
-        user.googleId = user.googleId || payload.sub;
-        user.emailVerified = true;
-        await user.save();
+    } else {
+        let changed = false;
+        if (!user.googleId) { user.googleId = payload.sub; changed = true; }
+        if (!user.emailVerified) { user.emailVerified = true; changed = true; }
+        // Existing accounts created before this fix still point straight at
+        // Google's CDN — migrate them the next time they sign in instead of
+        // needing a one-off backend script.
+        if (!user.profilePicture || user.profilePicture.includes("googleusercontent.com")) {
+            user.profilePicture = await rehostGoogleAvatar(payload.picture);
+            changed = true;
+        }
+        if (changed) await user.save();
     }
 
     return user;


### PR DESCRIPTION
## Root cause
A Google-signed-in user's \`profilePicture\` was stored as the raw \`googleusercontent.com\` URL from Google's ID token. That domain gets blocked by browser tracking prevention (Edge/Safari) and several ad/privacy-blocker filter lists when embedded in a third-party context — confirmed via the real browser console log from this exact account: \`Tracking Prevention blocked access to storage for https://lh3.googleusercontent.com/...\`. The avatar silently fails to render anywhere in the app, with no server-side error at all, which is why it looked like "the nav isn't rendering the image."

## Fix
Google login now re-hosts the avatar through our own Cloudinary immediately (\`cloudinary.uploader.upload\` accepts a remote URL directly and fetches it server-side, where no browser blocking applies) instead of depending on Google's CDN to keep serving it to every visitor's browser. Existing accounts created before this fix get migrated automatically on their next Google sign-in.

## Test plan
- [x] Uploaded the exact Google avatar URL from this account's own console log directly to Cloudinary — succeeded, produced a working, renderable image (confirmed by viewing it)
- [x] \`node --check\` clean
- [ ] Sign in again with the affected Google account, confirm the nav avatar now renders