### PR TITLE
Fix messaging responsive padding + stale chat flash; move profile fields

### DIFF
--- a/frontend/src/layout/DashboardLayout/styles.module.css
+++ b/frontend/src/layout/DashboardLayout/styles.module.css
@@ -643,6 +643,19 @@
         /* keeps content clear of the bottom tab bar */
     }
 
+    /* Messaging still wants edge-to-edge left/right/top below this
+       breakpoint too — a two-class selector so it actually beats the
+       single-class .mainRow rule above regardless of source order (equal
+       specificity resolves by position in the file, not media-query
+       truthiness, which is what let this padding silently come back for
+       messaging specifically). Bottom stays: that's real space for the
+       fixed bottom tab bar, not layout slack. */
+    .mainRow.mainRowFlush {
+        padding-top: 0;
+        padding-left: 0;
+        padding-right: 0;
+    }
+
     .sidebar {
         position: fixed;
         bottom: 0;

--- a/frontend/src/pages/messaging/[username].jsx
+++ b/frontend/src/pages/messaging/[username].jsx
@@ -204,6 +204,11 @@ export default function Messaging() {
     /* -------------------- FETCH CHAT -------------------- */
     useEffect(() => {
         if (activeChatUser?.userId?._id) {
+            // The previous thread's messages were still sitting in Redux —
+            // clearing them here (not just gating the loader) means there's
+            // no window where switching from A to B briefly shows A's
+            // bubbles while B's fetch is still in flight.
+            dispatch(resetMessages());
             setChatLoading(true);
             dispatch(getMessages({ receiverId: activeChatUser.userId._id })).finally(() => setChatLoading(false));
             dispatch(markMessagesRead({ senderId: activeChatUser.userId._id }));
@@ -683,14 +688,13 @@ export default function Messaging() {
                                     <div className="w-full flex items-center justify-center py-16">
                                         <BlastLoader size={48} />
                                     </div>
-                                ) : !showSearchModal && messages.length === 0 && (
+                                ) : !showSearchModal && messages.length === 0 ? (
                                     <EmptyState
                                         icon={MessageCircle}
                                         title="No messages yet"
                                         description={`Say hello to ${activeChatUser.userId?.name || 'your connection'} to start the conversation.`}
                                     />
-                                )}
-                                {(showSearchModal ? filteredMessages : messages).map((msg, idx) => {
+                                ) : (showSearchModal ? filteredMessages : messages).map((msg, idx) => {
                                     const senderId = msg.sender?.userId?._id || msg.sender?._id || msg.sender;
                                     const isMe = senderId === authState.user?.userId?._id;
                                     const isSelected = selectedMessages.includes(msg._id);

--- a/frontend/src/pages/profile/index.jsx
+++ b/frontend/src/pages/profile/index.jsx
@@ -2,7 +2,7 @@ import styles from "./index.module.css"
 import React, { useEffect, useState, useMemo } from 'react'
 import { Base_Url, clientServer } from '@/config'
 import { useDispatch, useSelector } from 'react-redux'
-import { getAboutUser, getConnectionRequest, updateUserProfile } from '@/config/redux/action/authAction'
+import { getAboutUser, getConnectionRequest, updateUserProfile, updateAccountSettings } from '@/config/redux/action/authAction'
 import { useRouter } from 'next/router'
 import { getPostsByUsername, getBookmarkedPosts, getLikedPosts } from '@/config/redux/action/postAction'
 import DashboardLayout from '@/layout/DashboardLayout' // Added for Tablet/Mobile logic
@@ -79,11 +79,13 @@ export default function Profile() {
 
   const [formData, setFormData] = useState({
     name: "",
+    username: "",
     bio: "",
     currentPost: "",
     pastWork: [],
     education: []
   });
+  const [usernameError, setUsernameError] = useState("");
 
   useEffect(() => {
     setMounted(true);
@@ -110,12 +112,14 @@ export default function Profile() {
     if (userProfile && userProfile.userId) { // Added userId check
       setFormData({
         name: userProfile.userId?.name || "",
+        username: userProfile.userId?.username || "",
         bio: userProfile.bio || "",
         currentPost: userProfile.currentPost || "",
         pastWork: userProfile.pastWork || [],
         education: userProfile.education || []
       });
       setIsDirty(false); // Reset dirty state on sync
+      setUsernameError("");
     }
   }, [userProfile, isEditModalOpen]);
 
@@ -188,13 +192,33 @@ export default function Profile() {
 
   const handleUpdateProfile = async (e) => {
     e.preventDefault();
-    const result = await dispatch(updateUserProfile({
-      ...formData
-    }));
+    setUsernameError("");
+
+    // Username lives on the User doc, not the Profile doc — a separate
+    // endpoint (with its own uniqueness check) handles it, same one Settings
+    // used to call directly before this moved here.
+    const trimmedUsername = formData.username.trim();
+    if (trimmedUsername !== userProfile.userId?.username) {
+      const usernameRegex = /^[a-zA-Z0-9_]{3,30}$/;
+      if (!usernameRegex.test(trimmedUsername)) {
+        setUsernameError("3-30 characters, letters/numbers/underscores only");
+        return;
+      }
+      const usernameResult = await dispatch(updateAccountSettings({ username: trimmedUsername }));
+      if (!updateAccountSettings.fulfilled.match(usernameResult)) {
+        setUsernameError(usernameResult.payload?.message || "Username already taken");
+        return;
+      }
+    }
+
+    const { username, ...profileFields } = formData;
+    const result = await dispatch(updateUserProfile(profileFields));
 
     if (updateUserProfile.fulfilled.match(result)) {
       setIsEditModalOpen(false);
       dispatch(getAboutUser());
+    } else {
+      toast.error(result.payload?.message || 'Failed to update profile');
     }
   };
 
@@ -540,6 +564,26 @@ export default function Profile() {
                 <div className={styles.formGroup}>
                   <label>Full Name</label>
                   <input type="text" value={formData.name} onChange={(e) => updateForm({ ...formData, name: e.target.value })} placeholder="Your full name" />
+                </div>
+                <div className={styles.formGroup}>
+                  <label>Username</label>
+                  <input
+                    type="text"
+                    value={formData.username}
+                    onChange={(e) => {
+                      setUsernameError("");
+                      updateForm({ ...formData, username: e.target.value.replace(/\s/g, '') });
+                    }}
+                    placeholder="username"
+                  />
+                  {usernameError && <p className={styles.fieldError}>{usernameError}</p>}
+                </div>
+                <div className={styles.formGroup}>
+                  <label>Email</label>
+                  <input type="email" value={userProfile?.userId?.email || ''} disabled />
+                  <p className={styles.fieldHint}>
+                    {userProfile?.userId?.googleId ? "Managed by your Google account" : "Contact support to change your email"}
+                  </p>
                 </div>
                 <div className={styles.formGroup}>
                   <label>Current Designation</label>

--- a/frontend/src/pages/profile/index.module.css
+++ b/frontend/src/pages/profile/index.module.css
@@ -583,6 +583,23 @@
   background: var(--mt-surface);
 }
 
+.formGroup input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.fieldError {
+  font-size: 12px;
+  color: var(--mt-danger);
+  margin: 0;
+}
+
+.fieldHint {
+  font-size: 11.5px;
+  color: var(--mt-ink3);
+  margin: 0;
+}
+
 .divider {
   border: none;
   border-top: 1px solid var(--mt-border);

--- a/frontend/src/pages/settings/index.jsx
+++ b/frontend/src/pages/settings/index.jsx
@@ -15,7 +15,6 @@ import {
     UsersRound,
     Bell,
     UserCog,
-    Mail,
     KeyRound,
     Lock,
     UserX,
@@ -35,9 +34,6 @@ export default function Settings() {
     const { user, twoFactorEnabled } = useSelector(state => state.auth);
     const { unreadCount } = useNotification();
     const [theme, setTheme] = useState('system'); // light, dark, system
-    const [showUsernameModal, setShowUsernameModal] = useState(false);
-    const [usernameInput, setUsernameInput] = useState('');
-    const [savingUsername, setSavingUsername] = useState(false);
     const [loaded2FA, setLoaded2FA] = useState(false);
     const [dismissedTwoFactorNudge, setDismissedTwoFactorNudge] = useState(true);
 
@@ -65,28 +61,6 @@ export default function Settings() {
         if (window.confirm("Are you sure you want to log out?")) {
             dispatch(logout());
             router.push('/login');
-        }
-    };
-
-    const openUsernameModal = () => {
-        setUsernameInput(user?.userId?.username || '');
-        setShowUsernameModal(true);
-    };
-
-    const handleSaveUsername = async () => {
-        const trimmed = usernameInput.trim();
-        if (!trimmed || trimmed === user?.userId?.username) {
-            setShowUsernameModal(false);
-            return;
-        }
-        setSavingUsername(true);
-        const result = await dispatch(updateAccountSettings({ username: trimmed }));
-        setSavingUsername(false);
-        if (updateAccountSettings.fulfilled.match(result)) {
-            toast.success('Username updated');
-            setShowUsernameModal(false);
-        } else {
-            toast.error(result.payload?.message || 'Failed to update username');
         }
     };
 
@@ -199,14 +173,9 @@ export default function Settings() {
                 <div className={`${styles.group} mt-enter`} style={{ animationDelay: '50ms' }}>
                     <SettingsItem
                         icon={UserCog}
-                        label="Username"
-                        sub={`@${user?.userId?.username || ''}`}
-                        onClick={openUsernameModal}
-                    />
-                    <SettingsItem
-                        icon={Mail}
-                        label="Email"
-                        sub={user?.userId?.email || ''}
+                        label="Edit profile"
+                        sub="Name, username, bio, experience, education"
+                        onClick={() => router.push('/profile')}
                     />
                     {!user?.userId?.googleId && (
                         <SettingsItem
@@ -399,38 +368,6 @@ export default function Settings() {
                     Log out, which is exactly the kind of thing a misclick
                     lands on. It's reachable only through Help & Support's
                     guide now, adding real deliberate steps in between. */}
-
-                {showUsernameModal && (
-                    <div className={styles.modalOverlay} onClick={() => !savingUsername && setShowUsernameModal(false)}>
-                        <div className={styles.modalBox} onClick={(e) => e.stopPropagation()}>
-                            <h3 className={styles.modalTitle}>Change username</h3>
-                            <input
-                                type="text"
-                                value={usernameInput}
-                                onChange={(e) => setUsernameInput(e.target.value.replace(/\s/g, ''))}
-                                className={styles.modalInput}
-                                placeholder="username"
-                            />
-                            <div className={styles.modalActions}>
-                                <button
-                                    className={styles.modalCancelBtn}
-                                    onClick={() => setShowUsernameModal(false)}
-                                    disabled={savingUsername}
-                                >
-                                    Cancel
-                                </button>
-                                <button
-                                    className={styles.modalDeleteBtn}
-                                    onClick={handleSaveUsername}
-                                    disabled={savingUsername || !usernameInput.trim()}
-                                    style={{ background: 'var(--mt-grad)' }}
-                                >
-                                    {savingUsername ? 'Saving…' : 'Save'}
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                )}
 
                 <div className={styles.footer}>
                     <p>Mitrata App v1.2.0</p>


### PR DESCRIPTION
## Summary
- Messaging's full-bleed layout lost its edge-to-edge look below the 1224px breakpoint (odd padding reappearing) — a CSS specificity/source-order bug, fixed with a combined selector that wins regardless of order while keeping the bottom tab-bar clearance.
- Switching conversations flashed the previous thread's messages before the new one loaded — the loading flag didn't actually gate the message list render, and the old messages were never cleared on switch. Both fixed.
- Username and email move from Settings into Profile's edit modal (with everything else profile-related); Settings' Account section is now a single "Edit profile" shortcut plus the security items that actually belong there (password, 2FA, login activity).

## Test plan
- [x] Verified live against a real account: username field edits and saves correctly, reflected immediately
- [x] `npx next build` clean
- [ ] Manually confirm the messaging padding fix at a few widths around 1224px, and that switching chats no longer flashes the previous thread