### PR TITLE
Fix connection request race condition + make accept/send instant

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -897,7 +897,18 @@ export const sendconnectionrequest = async (req, res) => {
             status_accepted: null
         });
 
-        await request.save();
+        try {
+            await request.save();
+        } catch (saveError) {
+            // The unique pairKey index catching a genuine race — someone else's
+            // request for this exact pair landed between our findOne check
+            // above and this save. Same friendly message as the check above,
+            // not a raw 500.
+            if (saveError.code === 11000) {
+                return res.status(400).json({ message: "Request already pending" });
+            }
+            throw saveError;
+        }
 
         // Create persistent notification
         await Notification.create({
@@ -928,7 +939,24 @@ export const sendconnectionrequest = async (req, res) => {
             data: { type: "connection_request", requestId: request._id.toString() }
         }).catch((err) => console.error("sendPush failed:", err.message));
 
-        return res.json({ message: "Request sent successfully" });
+        // Same shape getMyConnectionRequest returns per-item — lets the
+        // frontend patch this one new request straight into state instead
+        // of refetching the entire connections list just to show it.
+        return res.json({
+            message: "Request sent successfully",
+            connection: {
+                _id: request._id,
+                status_accepted: null,
+                iAmSender: true,
+                userId: {
+                    _id: connectionUser._id,
+                    name: connectionUser.name,
+                    username: connectionUser.username,
+                    email: connectionUser.email,
+                    profilePicture: connectionUser.profilePicture
+                }
+            }
+        });
     } catch (error) {
         return res.status(500).json({ message: error.message });
     }
@@ -1011,7 +1039,8 @@ export const acceptConnectionRequest = async (req, res) => {
         const user = await User.findById(req.userId);
         if (!user) return res.status(404).json({ message: "User not found" });
 
-        const connection = await ConnectionRequest.findOne({ _id: requestId });
+        const connection = await ConnectionRequest.findOne({ _id: requestId })
+            .populate('userId', 'name username email profilePicture');
         if (!connection) {
             return res.status(400).json({ message: "Connection request not found" });
         }
@@ -1035,10 +1064,12 @@ export const acceptConnectionRequest = async (req, res) => {
         connection.status_accepted = (action_type === 'accept');
         await connection.save();
 
+        const senderId = connection.userId._id;
+
         // If accepted, notify the sender — only on the actual transition
         if (wasPending && action_type === 'accept') {
             await Notification.create({
-                userId: connection.userId,
+                userId: senderId,
                 type: 'connection_accepted',
                 fromUser: user._id,
                 message: `${user.name} accepted your connection request`
@@ -1046,7 +1077,7 @@ export const acceptConnectionRequest = async (req, res) => {
 
             const io = req.app.get('socketio');
             if (io) {
-                io.to(connection.userId.toString()).emit('connectionAccepted', {
+                io.to(senderId.toString()).emit('connectionAccepted', {
                     fromUser: {
                         _id: user._id,
                         name: user.name,
@@ -1056,17 +1087,26 @@ export const acceptConnectionRequest = async (req, res) => {
                     message: `${user.name} accepted your connection request`
                 });
             }
-            sendPush(connection.userId, {
+            sendPush(senderId, {
                 title: "Connection accepted",
                 body: `${user.name} accepted your connection request`,
                 data: { type: "connection_accepted", username: user.username }
             }).catch((err) => console.error("sendPush failed:", err.message));
         }
 
+        // Same shape getMyConnectionRequest returns per-item — lets the
+        // frontend patch this one request's new status straight into state
+        // instead of refetching the whole connections + requests lists.
         return res.status(200).json({
             message: action_type === 'accept'
                 ? "Connection accepted"
-                : "Connection rejected"
+                : "Connection rejected",
+            connection: {
+                _id: connection._id,
+                status_accepted: connection.status_accepted,
+                iAmSender: false,
+                userId: connection.userId
+            }
         });
     } catch (error) {
         return res.status(500).json({ message: error.message });

--- a/backend/models/connection.model.js
+++ b/backend/models/connection.model.js
@@ -12,7 +12,32 @@ const connectionSchema =    new mongoose.Schema({
         type:Boolean,
         default:null
     },
+    // Direction-independent identity for a pair — "userA_userB" with the two
+    // ids sorted, so (A,B) and (B,A) collide on the same key regardless of
+    // who sent the request. The unique index on it is what actually
+    // prevents two near-simultaneous sendconnectionrequest calls between the
+    // same pair from both passing the existence check and inserting two
+    // documents — the app-level findOne-then-save check alone can't close
+    // that race, only a DB-level constraint can.
+    // sparse: existing documents from before this field existed have no
+    // pairKey at all — a plain unique index would fail to even build over
+    // multiple such "missing" values. Sparse excludes them from the
+    // constraint while still fully enforcing uniqueness among every
+    // document that DOES have one, which is every document created from
+    // here on — exactly the ones actually at risk of a fresh race.
+    pairKey: {
+        type: String,
+        unique: true,
+        sparse: true,
+    },
 })
+
+connectionSchema.pre("validate", function (next) {
+    if (this.userId && this.connectionId) {
+        this.pairKey = [this.userId.toString(), this.connectionId.toString()].sort().join("_");
+    }
+    next();
+});
 
 // Every connection-related read (feed ranking, suggestions, stories,
 // my-network, request-already-exists checks) queries by one of these two

--- a/frontend/src/config/redux/action/authAction/index.js
+++ b/frontend/src/config/redux/action/authAction/index.js
@@ -403,10 +403,13 @@ export const sendConnectionRequest = createAsyncThunk(
     async (user, thunkApi) => {
         try {
             // Token is auto-attached via axios interceptor
+            // Backend now hands back the new request already in the shape
+            // getConnectionRequest's list uses per-item — the reducer patches
+            // it straight into state.connection, no need to refetch the
+            // whole list just to show this one row.
             const response = await clientServer.post('/user/send_connection_request', {
                 connectionId: user.connectionId
             })
-            thunkApi.dispatch(getConnectionRequest())
             return thunkApi.fulfillWithValue(response.data)
         } catch (error) {
             return thunkApi.rejectWithValue(error.response?.data || { message: "Request failed" })

--- a/frontend/src/config/redux/reducer/authReducer/index.js
+++ b/frontend/src/config/redux/reducer/authReducer/index.js
@@ -1,5 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { getAboutUser, loginUser, registerUser, getAllUser, getConnectionRequest, getMyConnectionRequests, acceptConnectionRequest, downloadResume, updateUserProfile, updateAccountSettings, blockUser, unblockUser, getBlockedUsers, logout, verifyOtp, resendOtp, sendOtp, resetPasswordAction, deleteAccount, switchAccountAction, verifyTwoFactorLogin, getTwoFactorStatus, completeGoogleLogin } from "../../action/authAction/index";
+import { getAboutUser, loginUser, registerUser, getAllUser, getConnectionRequest, getMyConnectionRequests, sendConnectionRequest, acceptConnectionRequest, downloadResume, updateUserProfile, updateAccountSettings, blockUser, unblockUser, getBlockedUsers, logout, verifyOtp, resendOtp, sendOtp, resetPasswordAction, deleteAccount, switchAccountAction, verifyTwoFactorLogin, getTwoFactorStatus, completeGoogleLogin } from "../../action/authAction/index";
 import { rememberAccount } from "../../../savedAccounts";
 
 
@@ -184,9 +184,36 @@ const authSlice = createSlice({
             .addCase(getMyConnectionRequests.pending, (state) => {
                 state.isLoading = true
             })
+            .addCase(sendConnectionRequest.fulfilled, (state, action) => {
+                state.isError = false;
+                state.message = action.payload.message;
+                // Patched directly instead of a full getConnectionRequest()
+                // refetch — the backend already hands back this exact shape.
+                if (action.payload.connection) {
+                    state.connection = [...(state.connection || []), action.payload.connection];
+                }
+            })
+            .addCase(sendConnectionRequest.rejected, (state, action) => {
+                state.isError = true;
+                state.message = action.payload?.message;
+            })
             .addCase(acceptConnectionRequest.fulfilled, (state, action) => {
-                state.isError = false,
-                    state.message = action.payload.message
+                state.isError = false;
+                state.message = action.payload.message;
+                const updated = action.payload.connection;
+                if (updated) {
+                    state.connection = (state.connection || []).map((c) =>
+                        c._id === updated._id ? { ...c, status_accepted: updated.status_accepted } : c
+                    );
+                    // Accepting also means it now belongs in the accepted-only
+                    // list a full getMyConnectionRequests() would return.
+                    if (updated.status_accepted === true) {
+                        const alreadyThere = (state.connectionRequest || []).some((c) => c._id === updated._id);
+                        if (!alreadyThere) {
+                            state.connectionRequest = [...(state.connectionRequest || []), updated];
+                        }
+                    }
+                }
             })
             .addCase(acceptConnectionRequest.rejected, (state, action) => {
                 state.isError = true;

--- a/frontend/src/pages/my_network/index.jsx
+++ b/frontend/src/pages/my_network/index.jsx
@@ -91,12 +91,13 @@ export default function MyNetwork() {
         if (processingRequestId) return;
         setProcessingRequestId(requestId);
         try {
+            // The reducer patches state.connection/connectionRequest directly
+            // from this response — no need to refetch both full lists just
+            // to reflect one row's status change.
             await dispatch(acceptConnectionRequest({
                 connectionId: requestId,
                 action: action
             })).unwrap();
-
-            refreshData();
         } catch (error) {
             console.error("Failed to update connection:", error);
             toast.error(error.message || "Failed to update connection");


### PR DESCRIPTION
## Findings & fixes

**Race condition (correctness):** \`sendconnectionrequest\` checked for an existing request then saved with no DB-level constraint — two near-simultaneous requests between the same pair could both pass the check and both insert. Added a direction-independent \`pairKey\` (sorted user ids) with a sparse unique index (sparse so it doesn't choke building over pre-existing documents that predate the field). Verified with 8 concurrent requests between a real pair: exactly 1 succeeds, DB ends up with exactly 1 document, the other 7 get a clean "already pending" instead of a raw 500 or a duplicate.

**Performance (the \"should be fastest\" ask):** accepting or sending a request triggered a full refetch of both the pending-requests list and the connections list — three network round trips to reflect one row's status change. Both endpoints now return the affected connection already populated (same shape the list endpoints use), and the reducer patches it directly into state. Verified live: accepting now fires exactly 1 network call instead of 3, with tab counts (Received/Connections) updating immediately and correctly.

**Verified as already correct, no changes needed:** blocked-user check in both directions, duplicate-request detection, the earlier "connection-accepted notification fires multiple times" fix (still holding via the wasPending guard).

## Test plan
- [x] 8 concurrent \`send_connection_request\` calls between a real pair — exactly 1 succeeds, DB has exactly 1 document
- [x] Live browser test: accept flow fires 1 network call (was 3), UI counts update correctly without a refetch
- [x] \`npx next build\` clean, backend \`node --check\` clean