### PR TITLE
Fix calls silently failing to a user who "shows online"

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -49,7 +49,15 @@ const io = new Server(httpServer, {
     origin: allowedOrigins,
     methods: ["GET", "POST"],
     credentials: true
-  }
+  },
+  // Defaults (pingInterval 25s + pingTimeout 20s) mean an abruptly-dropped
+  // connection — laptop lid closed, network cut, tab killed, no clean
+  // disconnect handshake — can sit in onlineUsers as "online" for up to
+  // ~45s before the server notices. During that window the UI still shows
+  // a green dot, but there's no live socket to actually deliver a call to.
+  // Shorter timers don't remove that window, just shrink it.
+  pingInterval: 10000,
+  pingTimeout: 8000
 });
 
 // ============ SECURITY MIDDLEWARE ============
@@ -247,7 +255,27 @@ io.on("connection", (socket) => {
   // ============ WEBRTC VOICE CALLING SIGNALING ============
   socket.on("callUser", (data) => {
     // data: { receiverId, offer, callerInfo: { name, avatar }, isVideo }
-    io.to(data.receiverId).emit("incomingCall", {
+    const receiverId = data.receiverId?.toString();
+    const receiverRoom = io.sockets.adapter.rooms.get(receiverId);
+
+    // onlineUsers can say "online" for a socket that's actually already
+    // dead (see the pingTimeout comment above) — the room membership check
+    // here is the real-time truth: it reflects only sockets Socket.IO has
+    // confirmed are still connected. If it's empty, `io.to(receiverId).emit`
+    // below would silently go nowhere, and the caller would otherwise sit
+    // in ringback for the full 30s client-side timeout with zero feedback.
+    // Telling them immediately, and reconciling the stale presence entry,
+    // is strictly better than waiting to find out the same way regardless.
+    if (!receiverRoom || receiverRoom.size === 0) {
+      if (onlineUsers.has(receiverId)) {
+        onlineUsers.delete(receiverId);
+        io.emit("userOffline", { userId: receiverId });
+      }
+      socket.emit("callFailed", { targetId: receiverId, reason: "offline" });
+      return;
+    }
+
+    io.to(receiverId).emit("incomingCall", {
       callerId: userId,
       callerInfo: data.callerInfo,
       offer: data.offer,

--- a/frontend/src/Components/CallProvider/index.jsx
+++ b/frontend/src/Components/CallProvider/index.jsx
@@ -426,12 +426,25 @@ export function CallProvider({ children }) {
             setRemoteRinging(true);
         };
 
+        // The receiver's presence can say "online" while their actual socket
+        // is already gone (network drop, closed lid — Socket.IO hasn't
+        // noticed yet, see the server's pingTimeout comment). The server
+        // now checks real room membership at call time instead of firing
+        // blind, so this fires almost immediately instead of the caller
+        // sitting in ringback for the full 30s client-side timeout with no
+        // feedback at all.
+        const handleCallFailed = (data) => {
+            toast.error("That person isn't reachable right now — they may have just gone offline.");
+            cleanupCall();
+        };
+
         socketInstance.on('incomingCall', handleIncomingCall);
         socketInstance.on('callAnswered', handleCallAnswered);
         socketInstance.on('iceCandidate', handleIceCandidate);
         socketInstance.on('callEnded', handleCallEnded);
         socketInstance.on('callRejected', handleCallRejected);
         socketInstance.on('callDelivered', handleCallDelivered);
+        socketInstance.on('callFailed', handleCallFailed);
 
         return () => {
             socketInstance.off('incomingCall', handleIncomingCall);
@@ -440,6 +453,7 @@ export function CallProvider({ children }) {
             socketInstance.off('callEnded', handleCallEnded);
             socketInstance.off('callRejected', handleCallRejected);
             socketInstance.off('callDelivered', handleCallDelivered);
+            socketInstance.off('callFailed', handleCallFailed);
         };
     }, [socketInstance, callState, cleanupCall]);
 


### PR DESCRIPTION
## Root cause
Online presence (\`onlineUsers\`) reflects the last clean disconnect Socket.IO saw — an abruptly-dropped connection (closed laptop lid, network cut, killed tab) has no clean disconnect handshake, so it can sit marked "online" for up to Socket.IO's default ping-timeout window (~45s) before the server actually notices it's gone. \`callUser\` fired \`incomingCall\` into that user's room regardless of whether anything was actually there to receive it — if the room was empty, the emit silently went nowhere, and the caller sat in ringback for the full 30s client-side timeout with zero feedback. That's exactly "shows online but the call never arrives."

Not related to multiple accounts/devices specifically: a call already broadcasts to every socket joined to a user's room (\`socket.join(userId)\`), so someone with several tabs/devices open all correctly receive an incoming call today — the gap was purely presence staleness + no delivery feedback.

## Fix
- \`callUser\` now checks real room membership (Socket.IO's own live truth) before emitting. If empty, it immediately emits a new \`callFailed\` back to the caller and evicts the stale \`onlineUsers\` entry, instead of firing blind.
- Frontend shows an immediate "not reachable" toast and cleans up call state on \`callFailed\`, instead of waiting out the blind 30s timeout.
- Shrunk Socket.IO's \`pingInterval\`/\`pingTimeout\` so a genuinely-dead connection is detected sooner regardless.

## Test plan
- [x] Real socket.io-client test: calling a user with an actually-dead connection now returns \`callFailed\` in ~0ms
- [x] Real socket.io-client test: calling a genuinely connected user still delivers \`incomingCall\` normally (no regression)
- [x] \`npx next build\` clean, backend \`node --check\` clean