### PR TITLE
Optimistic message send + reconnect resync (no infra rewrite)

### DIFF
--- a/frontend/src/config/redux/reducer/messageReducer/index.js
+++ b/frontend/src/config/redux/reducer/messageReducer/index.js
@@ -89,21 +89,57 @@ const messageSlice = createSlice({
             })
 
             /* ---------------- SEND MESSAGE ---------------- */
-            .addCase(sendMessage.pending, (state) => {
+            .addCase(sendMessage.pending, (state, action) => {
                 state.isLoading = true;
                 state.isError = false;
                 state.errorMessage = null;
+
+                // A real optimistic placeholder — the actual round trip
+                // (DB write, Cloudinary upload if there's media) can take a
+                // beat, and showing nothing in the thread until it resolves
+                // is what made sending feel laggy. RTK auto-attaches a
+                // requestId to every dispatch of this thunk, shared across
+                // its pending/fulfilled/rejected — used here purely to find
+                // and replace/flag THIS specific placeholder later, not sent
+                // to the server.
+                const { receiverId, content, senderId, media } = action.meta.arg;
+                state.messages.push({
+                    _id: `pending-${action.meta.requestId}`,
+                    __pendingId: action.meta.requestId,
+                    __status: 'sending',
+                    // File objects aren't kept here (Redux state should stay
+                    // serializable) — __hadMedia just lets a failed retry
+                    // warn that any attachment needs to be re-picked, rather
+                    // than silently retrying text-only and dropping it.
+                    __hadMedia: !!(media && media.length > 0),
+                    content: content || '',
+                    media: [],
+                    sender: senderId,
+                    receiver: receiverId,
+                    isRead: false,
+                    createdAt: new Date().toISOString(),
+                });
             })
             .addCase(sendMessage.fulfilled, (state, action) => {
                 state.isLoading = false;
-
-                // Push sent message instantly (optimistic UI)
-                state.messages.push(action.payload);
+                const idx = state.messages.findIndex((m) => m.__pendingId === action.meta.requestId);
+                if (idx !== -1) {
+                    state.messages[idx] = action.payload;
+                } else {
+                    state.messages.push(action.payload);
+                }
             })
             .addCase(sendMessage.rejected, (state, action) => {
                 state.isLoading = false;
                 state.isError = true;
                 state.errorMessage = action.payload?.message || "Failed to send message";
+                // Left in the thread flagged as failed (not removed) — losing
+                // what you just typed silently on a network blip is worse
+                // than showing a "failed, tap to retry" bubble.
+                const idx = state.messages.findIndex((m) => m.__pendingId === action.meta.requestId);
+                if (idx !== -1) {
+                    state.messages[idx].__status = 'failed';
+                }
             })
 
             /* ---------------- DELETE CHAT ---------------- */

--- a/frontend/src/pages/messaging/[username].jsx
+++ b/frontend/src/pages/messaging/[username].jsx
@@ -217,6 +217,26 @@ export default function Messaging() {
         }
     }, [activeChatUser, dispatch]);
 
+    // A socket only delivers "newMessage" while it's actually connected —
+    // anything sent during a disconnect (network blip, laptop sleep, the
+    // brief window before the server's ping-timeout notices a dead
+    // connection) never arrives, and nothing was resyncing afterward. A
+    // chat left open across a reconnect could sit stale until the user
+    // happened to navigate away and back. socket.io-client's `reconnect`
+    // (on the underlying Manager, not the Socket itself) fires specifically
+    // on a RECONNECT — not the first connect, which the FETCH CHAT effect
+    // above already covers — so this only does extra work when it's
+    // actually needed.
+    useEffect(() => {
+        if (!socket.current || !activeChatUser?.userId?._id) return;
+        const receiverId = activeChatUser.userId._id;
+        const handleReconnect = () => {
+            dispatch(getMessages({ receiverId }));
+        };
+        socket.current.io.on('reconnect', handleReconnect);
+        return () => socket.current?.io.off('reconnect', handleReconnect);
+    }, [socket, activeChatUser, dispatch]);
+
     // The other person read our messages while this thread is open — flip
     // our sent bubbles to the read state. This ignored WHO the read receipt
     // was actually from and marked the entire open thread read regardless —
@@ -316,26 +336,56 @@ export default function Messaging() {
 
         if (!message.trim() && selectedFiles.length === 0) return;
 
+        const content = message;
+        const media = selectedFiles;
+
+        // Cleared immediately, not after the round trip resolves — the
+        // optimistic placeholder (see sendMessage.pending in messageReducer)
+        // shows up in the thread right away, so there's no reason typing
+        // the next message should have to wait on the network.
+        setMessage("");
+        setSelectedFiles([]);
         setSending(true);
+        if (socket.current) {
+            socket.current.emit("stopTyping", { receiverId });
+        }
 
         try {
             await dispatch(sendMessage({
                 receiverId,
-                content: message,
-                media: selectedFiles
+                content,
+                media,
+                senderId: authState.user?.userId?._id
             })).unwrap();
-
-            setMessage("");
-            setSelectedFiles([]);
-            // Emit stop typing
-            if (socket.current && activeChatUser?.userId?._id) {
-                socket.current.emit("stopTyping", { receiverId: activeChatUser.userId._id });
-            }
         } catch (error) {
             console.error("Error sending message:", error);
-            toast.error("Failed to send message. Please try again.");
+            toast.error("Message failed to send — tap it to retry.");
         } finally {
             setSending(false);
+        }
+    };
+
+    // A failed send is left in the thread (see sendMessage.rejected) instead
+    // of silently vanishing — tapping it retries with the same content.
+    // Attachments aren't kept in Redux state (see __hadMedia), so a failed
+    // message that had media can only retry its text; the user re-picks
+    // the photo/video themselves rather than it silently vanishing.
+    const handleRetryMessage = async (msg) => {
+        if (msg.__hadMedia) {
+            toast.error("Couldn't retry the attachment automatically — please resend the photo/video.");
+        }
+        dispatch(removeDeletedMessages({ messageIds: [msg._id] }));
+        const receiverId = activeChatUser?.userId?._id;
+        if (!receiverId || !msg.content) return;
+        try {
+            await dispatch(sendMessage({
+                receiverId,
+                content: msg.content,
+                media: [],
+                senderId: authState.user?.userId?._id
+            })).unwrap();
+        } catch (error) {
+            toast.error("Still couldn't send — check your connection.");
         }
     };
 
@@ -703,13 +753,14 @@ export default function Messaging() {
                                         <div
                                             key={msg._id || idx}
                                             className={`${isMe ? styles.sentMsg : styles.receivedMsg} ${isSelected ? styles.selectedMsg : ''
-                                                } ${selectionMode ? styles.selectableMsg : ''}`}
+                                                } ${selectionMode ? styles.selectableMsg : ''} ${msg.__status === 'sending' ? styles.sendingMsg : ''
+                                                } ${msg.__status === 'failed' ? styles.failedMsg : ''}`}
                                             onMouseDown={() => handleLongPressStart(msg._id)}
                                             onMouseUp={handleLongPressEnd}
                                             onMouseLeave={handleLongPressEnd}
                                             onTouchStart={() => handleLongPressStart(msg._id)}
                                             onTouchEnd={handleLongPressEnd}
-                                            onClick={() => handleMessageClick(msg._id)}
+                                            onClick={() => msg.__status === 'failed' ? handleRetryMessage(msg) : handleMessageClick(msg._id)}
                                         >
                                             {selectionMode && (
                                                 <div className={styles.selectionCheckbox}>
@@ -767,12 +818,19 @@ export default function Messaging() {
                                                 </div>
                                             )}
                                             {msg.content && <p>{msg.content}</p>}
+                                            {msg.__status === 'failed' && (
+                                                <p className={styles.sendFailedHint}>Failed to send · tap to retry</p>
+                                            )}
                                             <span className={styles.timeStamp}>
-                                                {new Date(msg.createdAt).toLocaleTimeString([], {
-                                                    hour: "2-digit",
-                                                    minute: "2-digit"
-                                                })}
-                                                {isMe && (
+                                                {msg.__status === 'sending' ? (
+                                                    'Sending…'
+                                                ) : (
+                                                    new Date(msg.createdAt).toLocaleTimeString([], {
+                                                        hour: "2-digit",
+                                                        minute: "2-digit"
+                                                    })
+                                                )}
+                                                {isMe && msg.__status !== 'sending' && msg.__status !== 'failed' && (
                                                     msg.isRead
                                                         ? <CheckCheck size={13} strokeWidth={2} className={styles.readTick} />
                                                         : <Check size={13} strokeWidth={2} />

--- a/frontend/src/pages/messaging/styles.module.css
+++ b/frontend/src/pages/messaging/styles.module.css
@@ -443,6 +443,21 @@
     white-space: pre-wrap;
 }
 
+.sendingMsg {
+    opacity: 0.6;
+}
+
+.failedMsg {
+    cursor: pointer;
+    border: 1px solid var(--mt-danger);
+}
+
+.sendFailedHint {
+    margin: 4px 0 0 !important;
+    font-size: 11.5px;
+    color: var(--mt-danger);
+}
+
 .selectableMsg {
     cursor: pointer;
     padding-left: 34px;


### PR DESCRIPTION
## Context
User asked whether messaging should move to Erlang/BEAM (WhatsApp's approach) or a full Firebase swap for "more real-time." Neither fits: BEAM solves a millions-of-concurrent-connections scaling problem this app doesn't have yet, and a Firebase swap would mean migrating the entire data model off MongoDB, not just chat. The actual complaint (confirmed with the user) was that messages feel laggy/unreliable — both fixable within the existing MongoDB + Socket.IO stack.

## Fixes
1. **Optimistic send.** Previously the input cleared and nothing appeared in the thread until the full round trip resolved (DB write + Cloudinary upload if there's media) — every message felt like it vanished for a beat. Now appends immediately via RTK's own per-dispatch `requestId`, replaced by the real message on success or flagged "failed — tap to retry" (content preserved, not lost) on failure.
2. **Reconnect resync.** The open chat thread never refetched after a socket reconnect (network blip, laptop sleep, the ping-timeout window from the earlier calling fix) — any message sent during that gap was simply never delivered and nothing caught up. Now listens for socket.io-client's own `reconnect` event (fires only on genuine reconnects, not the initial connect) and refetches.

## Test plan
- [x] Live browser test: message bubble appears in the DOM within ~10ms of hitting send (well before the network round trip)
- [x] Confirmed via the receiver's own inbox that the real persisted message correctly replaced the placeholder — no duplicate, no phantom
- [x] `npx next build` clean