### PR TITLE
Add Sign in with Apple

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -27,7 +27,7 @@ import { authenticator } from "otplib";
 import QRCode from "qrcode";
 
 import { issueOtp } from "./otp.controller.js";
-import { issueSession, rotateSession, hashToken, refreshCookieName, refreshCookieOptions, signTwoFactorChallenge, verifyTwoFactorChallenge, describeDevice, signGoogleSessionCode, verifyGoogleSessionCode } from "../utils/session.js";
+import { issueSession, rotateSession, hashToken, refreshCookieName, refreshCookieOptions, signTwoFactorChallenge, verifyTwoFactorChallenge, describeDevice, signOAuthSessionCode, verifyOAuthSessionCode } from "../utils/session.js";
 import { sendPush } from "../utils/push.js";
 
 const googleClient = process.env.GOOGLE_CLIENT_ID ? new OAuth2Client(process.env.GOOGLE_CLIENT_ID) : null;
@@ -416,12 +416,12 @@ export const googleLoginCallback = async (req, res) => {
     try {
         const user = await verifyAndUpsertGoogleUser(req.body.credential);
         // No issueSession/cookie here — this response is to a genuine
-        // cross-origin top-level navigation (see signGoogleSessionCode's
+        // cross-origin top-level navigation (see signOAuthSessionCode's
         // comment for why), so any cookie set on it would be scoped to the
         // wrong origin. The frontend exchanges this one-time code for a real
         // session via completeGoogleLogin below, over a normal same-origin
         // proxied request instead.
-        const code = signGoogleSessionCode(user._id);
+        const code = signOAuthSessionCode(user._id, "google");
         return res.redirect(`${process.env.FRONTEND_URL}/login?googleSessionCode=${code}`);
     } catch (error) {
         console.error("Google login callback error:", error.message);
@@ -439,7 +439,161 @@ export const completeGoogleLogin = async (req, res) => {
 
         let userId;
         try {
-            userId = verifyGoogleSessionCode(code);
+            userId = verifyOAuthSessionCode(code, "google");
+        } catch {
+            return res.status(401).json({ message: "Sign-in link expired, please try again" });
+        }
+
+        const user = await User.findById(userId);
+        if (!user || !user.active) return res.status(401).json({ message: "Account unavailable" });
+
+        const accessToken = await issueSession(res, user, req);
+        return res.json({ token: accessToken });
+    } catch (error) {
+        return res.status(500).json({ message: error.message });
+    }
+};
+
+// Apple's own JWKS (their public signing keys for Sign in with Apple) —
+// cached in-memory since keys rotate rarely; refetched at most once an hour
+// so a genuine rotation is picked up without hitting Apple on every login.
+let appleKeysCache = { keys: null, fetchedAt: 0 };
+const APPLE_KEYS_TTL_MS = 60 * 60 * 1000;
+
+// The Flutter iOS app's bundle identifier — not a secret, it's baked into
+// the shipped app. Native Sign in with Apple on iOS sets the id_token's
+// `aud` to this instead of the web Services ID (see verifyAndUpsertAppleUser).
+const IOS_BUNDLE_ID = "com.mitrata.mitrataMobile";
+
+const getApplePublicKey = async (kid) => {
+    if (!appleKeysCache.keys || Date.now() - appleKeysCache.fetchedAt > APPLE_KEYS_TTL_MS) {
+        const response = await fetch("https://appleid.apple.com/auth/keys");
+        const { keys } = await response.json();
+        appleKeysCache = { keys, fetchedAt: Date.now() };
+    }
+    const jwk = appleKeysCache.keys.find((k) => k.kid === kid);
+    if (!jwk) throw new Error("No matching Apple signing key found");
+    return crypto.createPublicKey({ key: jwk, format: "jwk" });
+};
+
+// Verifies Apple's identity token (a JWT Apple signs, RS256) against Apple's
+// own public keys — the same trust boundary Google's ID-token verification
+// gives us via google-auth-library, just done by hand since there's no
+// equivalent "apple-auth-library" dependency worth adding for one JWT
+// verification (Node's own crypto.createPublicKey already accepts JWK format
+// directly, so nothing extra to install).
+//
+// `appleUserJson` is Apple's separate `user` form field — a JSON string with
+// {name: {firstName, lastName}} that Apple sends ONLY on the very first
+// authorization (it never repeats the name on subsequent sign-ins), unlike
+// the id_token's `email` claim which is present every time.
+const verifyAndUpsertAppleUser = async (idToken, appleUserJson) => {
+    if (!process.env.APPLE_SERVICES_ID) {
+        const err = new Error("Apple login is not configured on this server");
+        err.status = 501;
+        throw err;
+    }
+    if (!idToken) {
+        const err = new Error("idToken is required");
+        err.status = 400;
+        throw err;
+    }
+
+    const [headerB64] = idToken.split(".");
+    const header = JSON.parse(Buffer.from(headerB64, "base64url").toString());
+    const publicKey = await getApplePublicKey(header.kid);
+
+    // Apple sets the token's `aud` claim to the Services ID for the web
+    // OAuth flow, but to the app's own Bundle ID for native iOS/macOS sign-in
+    // (Flutter's sign_in_with_apple on iOS) — accept either audience rather
+    // than only the web one, or every native mobile sign-in fails here.
+    const payload = jwt.verify(idToken, publicKey, {
+        algorithms: ["RS256"],
+        audience: [process.env.APPLE_SERVICES_ID, IOS_BUNDLE_ID].filter(Boolean),
+        issuer: "https://appleid.apple.com",
+    });
+
+    let name = null;
+    if (appleUserJson) {
+        try {
+            const parsed = JSON.parse(appleUserJson);
+            if (parsed.name) name = `${parsed.name.firstName || ""} ${parsed.name.lastName || ""}`.trim();
+        } catch {
+            // Malformed/missing — fall through to the email-derived name below.
+        }
+    }
+
+    let user = await User.findOne({ $or: [{ appleId: payload.sub }, { email: payload.email }] });
+    if (!user) {
+        const usernameBase = (payload.email || `apple${payload.sub}`).split("@")[0].replace(/[^a-zA-Z0-9_]/g, "");
+        let username = usernameBase;
+        let suffix = 0;
+        while (await User.findOne({ username })) {
+            suffix += 1;
+            username = `${usernameBase}${suffix}`;
+        }
+        user = new User({
+            name: name || usernameBase,
+            email: payload.email,
+            username,
+            appleId: payload.sub,
+            // Apple already verified this address — no OTP step needed.
+            emailVerified: true
+        });
+        await user.save();
+        await new Profile({ userId: user._id }).save();
+    } else if (!user.active) {
+        const err = new Error("This account has been suspended");
+        err.status = 403;
+        throw err;
+    } else {
+        let changed = false;
+        if (!user.appleId) { user.appleId = payload.sub; changed = true; }
+        if (!user.emailVerified) { user.emailVerified = true; changed = true; }
+        if (changed) await user.save();
+    }
+
+    return user;
+};
+
+// Native Sign in with Apple (Flutter's sign_in_with_apple package hands the
+// app an idToken directly — no browser, no redirect hop needed). Mirrors
+// googleLogin: verify once, issue our session, done in one round trip.
+export const appleLogin = async (req, res) => {
+    try {
+        const user = await verifyAndUpsertAppleUser(req.body.idToken, req.body.user);
+        const accessToken = await issueSession(res, user, req);
+        return res.json({ token: accessToken });
+    } catch (error) {
+        console.error("Apple login error:", error.message);
+        return res.status(error.status || 401).json({ message: error.status ? error.message : "Invalid Apple token" });
+    }
+};
+
+// Apple POSTs here as a real top-level navigation (response_mode=form_post),
+// exactly like Google's GSI redirect flow — same reasoning applies for why
+// this can't set a session cookie directly (see signOAuthSessionCode).
+export const appleLoginCallback = async (req, res) => {
+    const failUrl = `${process.env.FRONTEND_URL}/login?appleError=1`;
+    try {
+        const user = await verifyAndUpsertAppleUser(req.body.id_token, req.body.user);
+        const code = signOAuthSessionCode(user._id, "apple");
+        return res.redirect(`${process.env.FRONTEND_URL}/login?appleSessionCode=${code}`);
+    } catch (error) {
+        console.error("Apple login callback error:", error.message);
+        return res.redirect(failUrl);
+    }
+};
+
+// Completes appleLoginCallback's redirect hop — mirrors completeGoogleLogin.
+export const completeAppleLogin = async (req, res) => {
+    try {
+        const { code } = req.body || {};
+        if (!code) return res.status(400).json({ message: "Code is required" });
+
+        let userId;
+        try {
+            userId = verifyOAuthSessionCode(code, "apple");
         } catch {
             return res.status(401).json({ message: "Sign-in link expired, please try again" });
         }
@@ -778,7 +932,7 @@ export const getUserAndProfile = async (req, res) => {
         // req.userId is already a verified-to-exist user (see verifyToken) —
         // no need to re-fetch the User doc just to read its own id back.
         const userProfile = await Profile.findOne({ userId: req.userId })
-            .populate("userId", "name email username profilePicture coverPhoto createAt role googleId isPrivate pushEnabled quietHours");
+            .populate("userId", "name email username profilePicture coverPhoto createAt role googleId appleId isPrivate pushEnabled quietHours");
 
         if (!userProfile) {
             return res.status(404).json({ message: "profile not found" });

--- a/backend/models/users.model.js
+++ b/backend/models/users.model.js
@@ -26,9 +26,13 @@ const userSchema = new mongoose.Schema({
     },
     password: {
         type: String,
-        required: function () { return !this.googleId; }
+        required: function () { return !this.googleId && !this.appleId; }
     },
     googleId: {
+        type: String,
+        default: null
+    },
+    appleId: {
         type: String,
         default: null
     },

--- a/backend/routes/user.routes.js
+++ b/backend/routes/user.routes.js
@@ -1,6 +1,6 @@
 
 import multer from "multer";
-import { acceptConnectionRequest, downloadProfile, findSearchUser, getAllUserBasedOnUsername, getMyConnectionRequest, getUserAndProfile, login, logout, register, sendconnectionrequest, updateProfileData, updateUserProfile, updateAccountSettings, uploadCoverPhoto, uploadImage, uploadProfilePicture, whatAreMyConnection, searchUsers, getSuggestions, googleLogin, googleLoginCallback, refreshAccessToken, deleteMyAccount, switchAccount, registerFcmToken, unregisterFcmToken, blockUser, unblockUser, getBlockedUsers, verifyTwoFactorLogin, getTwoFactorStatus, setupTwoFactor, verifyTwoFactorSetup, disableTwoFactor, getSessions, revokeSession, revokeOtherSessions, completeGoogleLogin } from "../controllers/user.controller.js";
+import { acceptConnectionRequest, downloadProfile, findSearchUser, getAllUserBasedOnUsername, getMyConnectionRequest, getUserAndProfile, login, logout, register, sendconnectionrequest, updateProfileData, updateUserProfile, updateAccountSettings, uploadCoverPhoto, uploadImage, uploadProfilePicture, whatAreMyConnection, searchUsers, getSuggestions, googleLogin, googleLoginCallback, refreshAccessToken, deleteMyAccount, switchAccount, registerFcmToken, unregisterFcmToken, blockUser, unblockUser, getBlockedUsers, verifyTwoFactorLogin, getTwoFactorStatus, setupTwoFactor, verifyTwoFactorSetup, disableTwoFactor, getSessions, revokeSession, revokeOtherSessions, completeGoogleLogin, appleLoginCallback, completeAppleLogin, appleLogin } from "../controllers/user.controller.js";
 import { sendOtp, verifyOtp, resendOtp, resetPassword } from "../controllers/otp.controller.js";
 import { createReport } from "../controllers/admin.controller.js";
 import { Router } from "express"
@@ -18,6 +18,9 @@ router.route('/logout').post(logout);
 router.route('/auth/google').post(googleLogin);
 router.route('/auth/google/callback').post(googleLoginCallback);
 router.route('/auth/google/complete').post(completeGoogleLogin);
+router.route('/auth/apple').post(appleLogin);
+router.route('/auth/apple/callback').post(appleLoginCallback);
+router.route('/auth/apple/complete').post(completeAppleLogin);
 router.route('/auth/refresh').post(refreshAccessToken);
 router.route('/auth/send-otp').post(sendOtp);
 router.route('/auth/verify-otp').post(verifyOtp);

--- a/backend/server.js
+++ b/backend/server.js
@@ -67,14 +67,15 @@ app.use(helmet({
   // back to this origin — the default "same-origin" COOP silently blocks that.
   crossOriginOpenerPolicy: { policy: "same-origin-allow-popups" }
 }));
-// Google's redirect-mode sign-in POSTs here as a real top-level browser
-// navigation, not a JS fetch/XHR — browsers send a literal Origin: "null"
-// for that kind of cross-site form submission, which the origin check above
-// (correctly) rejects for everything else. CORS was never relevant to this
-// route in the first place: nothing reads the response via JS, so there's
-// nothing for a CORS header to protect here.
+// Google's and Apple's redirect-mode sign-in both POST here as a real
+// top-level browser navigation, not a JS fetch/XHR — browsers send a literal
+// Origin: "null" for that kind of cross-site form submission, which the
+// origin check above (correctly) rejects for everything else. CORS was
+// never relevant to either route in the first place: nothing reads the
+// response via JS, so there's nothing for a CORS header to protect here.
+const CORS_EXEMPT_PATHS = new Set(["/api/auth/google/callback", "/api/auth/apple/callback"]);
 app.use((req, res, next) => {
-  if (req.path === "/api/auth/google/callback") return next();
+  if (CORS_EXEMPT_PATHS.has(req.path)) return next();
   return cors(corsOptions)(req, res, next);
 });
 app.use(cookieParser());
@@ -104,6 +105,7 @@ const authLimiter = rateLimit({
 app.use("/api/login", authLimiter);
 app.use("/api/register", authLimiter);
 app.use("/api/auth/google", authLimiter);
+app.use("/api/auth/apple", authLimiter);
 app.use("/api/auth/2fa/verify-login", authLimiter); // guesses a 6-digit code — same budget as password guessing
 
 // Session upkeep, not credential guessing — generous ceiling just to blunt

--- a/backend/utils/session.js
+++ b/backend/utils/session.js
@@ -159,24 +159,28 @@ export const verifyTwoFactorChallenge = (token) => {
     return decoded.userId;
 };
 
-// Google's redirect sign-in flow is a genuine top-level browser navigation
-// straight to this backend's own origin (GSI POSTs to login_uri directly —
-// there's no way to route that hop through the frontend's same-origin proxy
-// the way every other request goes). A cookie set on THAT response would be
-// scoped to the backend's own host, not the frontend's — useless for every
-// later request, which all go through the proxy and only ever carry
-// frontend-scoped cookies. So googleLoginCallback doesn't set a cookie at
-// all; it hands back this one-time code instead, and the frontend exchanges
-// it via a normal proxied POST (see completeGoogleLogin), which DOES land
-// the cookie on the right origin, exactly like every other login path.
-const GOOGLE_SESSION_CODE_TTL = "2m";
+// Both Google's and Apple's redirect sign-in flows are genuine top-level
+// browser navigations straight to this backend's own origin (their
+// authorize/login endpoints POST directly to a redirect_uri here — there's
+// no way to route that hop through the frontend's same-origin proxy the way
+// every other request goes). A cookie set on THAT response would be scoped
+// to the backend's own host, not the frontend's — useless for every later
+// request, which all go through the proxy and only ever carry
+// frontend-scoped cookies. So neither provider's callback sets a cookie at
+// all; each hands back this one-time code instead, and the frontend
+// exchanges it via a normal proxied POST (see completeGoogleLogin/
+// completeAppleLogin), which DOES land the cookie on the right origin,
+// exactly like every other login path. One shared implementation since
+// nothing about it is actually provider-specific — only the `type` claim
+// differs, so a code minted for one provider can't be replayed as the other's.
+const OAUTH_SESSION_CODE_TTL = "2m";
 
-export const signGoogleSessionCode = (userId) =>
-    jwt.sign({ userId, type: "google_session_code" }, process.env.JWT_SECRET, { expiresIn: GOOGLE_SESSION_CODE_TTL });
+export const signOAuthSessionCode = (userId, provider) =>
+    jwt.sign({ userId, type: `${provider}_session_code` }, process.env.JWT_SECRET, { expiresIn: OAUTH_SESSION_CODE_TTL });
 
-export const verifyGoogleSessionCode = (token) => {
+export const verifyOAuthSessionCode = (token, provider) => {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
-    if (decoded.type !== "google_session_code") throw new Error("Invalid session code");
+    if (decoded.type !== `${provider}_session_code`) throw new Error("Invalid session code");
     return decoded.userId;
 };
 

--- a/frontend/src/Components/ui/AppleLoginButton.jsx
+++ b/frontend/src/Components/ui/AppleLoginButton.jsx
@@ -1,0 +1,49 @@
+const SERVICES_ID = process.env.NEXT_PUBLIC_APPLE_SERVICES_ID;
+const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+// Apple's sign-in is plain OAuth2/OIDC — unlike Google, there's no JS SDK
+// needed at all. A real top-level redirect (not a popup, not an iframe) is
+// both the simplest implementation and immune to the exact popup-blocking/
+// third-party-cookie issues Google's GSI popup flow ran into earlier in this
+// project — nothing to load, nothing to silently fail.
+//
+// response_mode=form_post is what makes Apple POST id_token (and, on first
+// authorization only, a `user` JSON blob with name/email) straight to
+// redirect_uri as a real top-level navigation — verified server-side in
+// appleLoginCallback. No client-side `state` param: same trust model already
+// established for Google here — the real boundary is the signed id_token's
+// signature/audience check on the backend, not a CSRF token on this hop.
+function buildAuthorizeUrl() {
+    const params = new URLSearchParams({
+        client_id: SERVICES_ID,
+        redirect_uri: `${BACKEND_URL}/api/auth/apple/callback`,
+        response_type: 'code id_token',
+        response_mode: 'form_post',
+        scope: 'name email',
+    });
+    return `https://appleid.apple.com/auth/authorize?${params.toString()}`;
+}
+
+export default function AppleLoginButton() {
+    if (!SERVICES_ID) {
+        return (
+            <p className="text-center text-xs text-gray-400">
+                Sign in with Apple isn&apos;t configured yet.
+            </p>
+        );
+    }
+
+    return (
+        <button
+            type="button"
+            onClick={() => { window.location.href = buildAuthorizeUrl(); }}
+            className="w-full flex items-center justify-center gap-2 rounded-full border border-gray-300 dark:border-gray-600 py-2.5 px-4 text-sm font-medium bg-black text-white hover:opacity-90 transition-opacity"
+            style={{ maxWidth: 320, margin: '0 auto' }}
+        >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M16.365 1.43c0 1.14-.416 2.11-1.25 2.907-.902.86-2.005 1.362-3.213 1.264-.14-1.11.362-2.24 1.194-3.02.9-.85 2.09-1.34 3.27-1.35zM20.4 17.36c-.51 1.18-.75 1.7-1.4 2.73-.9 1.42-2.17 3.2-3.75 3.21-1.4.01-1.76-.91-3.65-.9-1.9 0-2.29.9-3.68.9-1.58 0-2.78-1.6-3.68-3.02C1.4 16.94.5 12.5 2.1 9.51c.87-1.63 2.44-2.66 4.15-2.68 1.36-.02 2.65.92 3.48.92.83 0 2.39-1.14 4.03-.97.69.03 2.62.28 3.86 2.1-.1.06-2.3 1.35-2.28 4.03.02 3.2 2.8 4.27 2.83 4.28-.02.06-.44 1.53-1.53 3.03z" />
+            </svg>
+            Sign in with Apple
+        </button>
+    );
+}

--- a/frontend/src/config/redux/action/authAction/index.js
+++ b/frontend/src/config/redux/action/authAction/index.js
@@ -78,6 +78,23 @@ export const completeGoogleLogin = createAsyncThunk(
     }
 )
 
+// Second half of the Apple redirect flow — mirrors completeGoogleLogin
+// exactly, see its comment for why a cookie can't be set on Apple's own
+// cross-origin redirect response either.
+export const completeAppleLogin = createAsyncThunk(
+    "user/completeAppleLogin",
+    async (code, thunkApi) => {
+        try {
+            const response = await clientServer.post('/auth/apple/complete', { code });
+            if (!response.data.token) return thunkApi.rejectWithValue({ message: "token not provided" });
+            startNewSession(response.data.token);
+            return thunkApi.fulfillWithValue(response.data.token)
+        } catch (error) {
+            return thunkApi.rejectWithValue(error.response?.data || { message: "Apple sign-in failed" })
+        }
+    }
+)
+
 export const getTwoFactorStatus = createAsyncThunk(
     "user/getTwoFactorStatus",
     async (_arg, thunkApi) => {

--- a/frontend/src/config/redux/reducer/authReducer/index.js
+++ b/frontend/src/config/redux/reducer/authReducer/index.js
@@ -1,5 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
-import { getAboutUser, loginUser, registerUser, getAllUser, getConnectionRequest, getMyConnectionRequests, sendConnectionRequest, acceptConnectionRequest, downloadResume, updateUserProfile, updateAccountSettings, blockUser, unblockUser, getBlockedUsers, logout, verifyOtp, resendOtp, sendOtp, resetPasswordAction, deleteAccount, switchAccountAction, verifyTwoFactorLogin, getTwoFactorStatus, completeGoogleLogin } from "../../action/authAction/index";
+import { getAboutUser, loginUser, registerUser, getAllUser, getConnectionRequest, getMyConnectionRequests, sendConnectionRequest, acceptConnectionRequest, downloadResume, updateUserProfile, updateAccountSettings, blockUser, unblockUser, getBlockedUsers, logout, verifyOtp, resendOtp, sendOtp, resetPasswordAction, deleteAccount, switchAccountAction, verifyTwoFactorLogin, getTwoFactorStatus, completeGoogleLogin, completeAppleLogin } from "../../action/authAction/index";
 import { rememberAccount } from "../../../savedAccounts";
 
 
@@ -100,6 +100,23 @@ const authSlice = createSlice({
                 state.isLoading = false
                 state.isError = true
                 state.message = action.payload?.message || 'Google sign-in failed';
+            })
+            .addCase(completeAppleLogin.pending, (state) => {
+                state.isLoading = true
+                state.isError = false
+            })
+            .addCase(completeAppleLogin.fulfilled, (state) => {
+                state.isLoading = false
+                state.isSuccess = true
+                state.isError = false
+                state.loggedIn = true
+                state.isTokenThere = true
+                state.message = "login sucessfully"
+            })
+            .addCase(completeAppleLogin.rejected, (state, action) => {
+                state.isLoading = false
+                state.isError = true
+                state.message = action.payload?.message || 'Apple sign-in failed';
             })
             .addCase(verifyTwoFactorLogin.rejected, (state, action) => {
                 state.isLoading = false

--- a/frontend/src/config/savedAccounts.js
+++ b/frontend/src/config/savedAccounts.js
@@ -24,11 +24,12 @@ export const rememberAccount = (user) => {
         name: user.name,
         username: user.username,
         profilePicture: user.profilePicture,
-        // Whether this account signed up/links via Google — a Google-only
-        // account has no password at all, so if the saved-session cookie
-        // ever needs re-auth, the fallback must not be a password field it's
-        // literally impossible to fill in.
+        // Whether this account signed up/links via Google or Apple — neither
+        // has a password at all, so if the saved-session cookie ever needs
+        // re-auth, the fallback must not be a password field it's literally
+        // impossible to fill in.
         googleId: user.googleId || null,
+        appleId: user.appleId || null,
     };
     const existing = getSavedAccounts().filter((a) => a.email !== entry.email);
     const next = [entry, ...existing].slice(0, MAX_ACCOUNTS);

--- a/frontend/src/pages/help_support/delete_account/index.jsx
+++ b/frontend/src/pages/help_support/delete_account/index.jsx
@@ -25,7 +25,7 @@ export default function DeleteAccountPage() {
     const [confirmText, setConfirmText] = useState('');
     const [deleting, setDeleting] = useState(false);
 
-    const hasPassword = !user?.userId?.googleId;
+    const hasPassword = !user?.userId?.googleId && !user?.userId?.appleId;
 
     const handleDelete = async () => {
         if (confirmText !== DELETE_CONFIRM_WORD) return;

--- a/frontend/src/pages/login/index.jsx
+++ b/frontend/src/pages/login/index.jsx
@@ -3,12 +3,13 @@ import { useRouter } from 'next/router'
 import React, { useEffect, useRef, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import styles from './styles.module.css'
-import { loginUser, registerUser, verifyOtp, resendOtp, switchAccountAction, getAboutUser, verifyTwoFactorLogin, completeGoogleLogin } from '@/config/redux/action/authAction'
+import { loginUser, registerUser, verifyOtp, resendOtp, switchAccountAction, getAboutUser, verifyTwoFactorLogin, completeGoogleLogin, completeAppleLogin } from '@/config/redux/action/authAction'
 import { emptyMessage } from '@/config/redux/reducer/authReducer'
 import { getSavedAccounts } from '@/config/savedAccounts'
 import Button from '@/Components/ui/Button'
 import PasswordInput from '@/Components/ui/PasswordInput'
 import GoogleLoginButton from '@/Components/ui/GoogleLoginButton'
+import AppleLoginButton from '@/Components/ui/AppleLoginButton'
 import PageLoader from '@/Components/ui/PageLoader'
 
 const RESEND_COOLDOWN_S = 60;
@@ -32,7 +33,7 @@ function LoginComponent() {
   // that account has no password at all, so the normal email/password form
   // is a dead end for it; this instead surfaces just the Google button,
   // pre-aimed at the same account, one click instead of a form nobody can fill in.
-  const [googleReauthAccount, setGoogleReauthAccount] = useState(null);
+  const [oauthReauthAccount, setOauthReauthAccount] = useState(null);
 
   const [email, setEmail] = useState("");
   const [name, setName] = useState("");
@@ -62,6 +63,7 @@ function LoginComponent() {
   // completeGoogleLogin's comment) — only a one-time code, exchanged here
   // over a normal proxied request that DOES land the cookie correctly.
   const [googleAuthError, setGoogleAuthError] = useState(false);
+  const [appleAuthError, setAppleAuthError] = useState(false);
   useEffect(() => {
     if (!router.isReady) return;
     if (router.query.googleSessionCode) {
@@ -78,8 +80,25 @@ function LoginComponent() {
     } else if (router.query.googleError) {
       setGoogleAuthError(true);
       router.replace('/login', undefined, { shallow: true });
+    } else if (router.query.appleSessionCode) {
+      // Same exchange as Google's, just Apple's own redirect hop —
+      // see completeAppleLogin's comment for why this can't be a cookie
+      // set directly on that cross-origin response.
+      const code = String(router.query.appleSessionCode);
+      router.replace('/login', undefined, { shallow: true });
+      dispatch(completeAppleLogin(code)).then((result) => {
+        if (completeAppleLogin.fulfilled.match(result)) {
+          dispatch(getAboutUser());
+          router.push('/dashboard');
+        } else {
+          setAppleAuthError(true);
+        }
+      });
+    } else if (router.query.appleError) {
+      setAppleAuthError(true);
+      router.replace('/login', undefined, { shallow: true });
     }
-  }, [router.isReady, router.query.googleSessionCode, router.query.googleError]);
+  }, [router.isReady, router.query.googleSessionCode, router.query.googleError, router.query.appleSessionCode, router.query.appleError]);
 
   useEffect(() => {
     const token = localStorage.getItem("token");
@@ -116,12 +135,12 @@ function LoginComponent() {
       // Full reload, not a client-side push — see the identical note in
       // DashboardLayout's handleSwitchAccount for why.
       window.location.href = '/dashboard';
-    } else if (acc.googleId) {
+    } else if (acc.googleId || acc.appleId) {
       // No password exists for this account at all — dropping into the
       // email/password form here was a dead end that just looked like
       // "asking for a password" with nothing the user could type.
       setShowChooser(false);
-      setGoogleReauthAccount(acc);
+      setOauthReauthAccount(acc);
     } else {
       // That account's session actually expired — fall through to a normal,
       // prefilled sign-in instead of leaving them stuck.
@@ -217,7 +236,7 @@ function LoginComponent() {
         <div className={styles.cardContainer}>
           <div className={styles.cardContainer_left}>
             <p className={styles.cardHeading}>
-              {googleReauthAccount ? 'Sign in again' : authState.requires2FA ? 'Two-step verification' : verifyingEmail ? 'Verify your email' : showChooser ? 'Choose an account' : (userLoginMethod ? 'SignIn' : 'Signup')}
+              {oauthReauthAccount ? 'Sign in again' : authState.requires2FA ? 'Two-step verification' : verifyingEmail ? 'Verify your email' : showChooser ? 'Choose an account' : (userLoginMethod ? 'SignIn' : 'Signup')}
             </p>
 
             {/* General API Status Messages */}
@@ -231,6 +250,11 @@ function LoginComponent() {
                 Google sign-in failed. Please try again.
               </div>
             )}
+            {appleAuthError && (
+              <div className="text-sm mb-2.5 font-medium text-danger">
+                Apple sign-in failed. Please try again.
+              </div>
+            )}
 
             {/* Error specifically for Spaces */}
             {usernameError && !userLoginMethod && !verifyingEmail && (
@@ -239,23 +263,23 @@ function LoginComponent() {
                </div>
             )}
 
-            {googleReauthAccount ? (
+            {oauthReauthAccount ? (
               <div className={styles.inputContainer} style={{ textAlign: 'center' }}>
                 <img
-                  src={googleReauthAccount.profilePicture || '/default-avatar.svg'}
+                  src={oauthReauthAccount.profilePicture || '/default-avatar.svg'}
                   alt=""
                   style={{ width: 56, height: 56, borderRadius: '50%', objectFit: 'cover', margin: '0 auto 12px' }}
                 />
                 <p className="text-sm mb-1" style={{ color: 'var(--mt-ink)', fontWeight: 600 }}>
-                  {googleReauthAccount.name}
+                  {oauthReauthAccount.name}
                 </p>
                 <p className="text-sm mb-4" style={{ color: 'var(--mt-ink2)' }}>
-                  Your saved session expired — sign in again with Google to continue as {googleReauthAccount.email}.
+                  Your saved session expired — sign in again with {oauthReauthAccount.appleId ? 'Apple' : 'Google'} to continue as {oauthReauthAccount.email}.
                 </p>
-                <GoogleLoginButton />
+                {oauthReauthAccount.appleId ? <AppleLoginButton /> : <GoogleLoginButton />}
                 <button
                   type="button"
-                  onClick={() => { setGoogleReauthAccount(null); setShowChooser(savedAccounts.length > 0); }}
+                  onClick={() => { setOauthReauthAccount(null); setShowChooser(savedAccounts.length > 0); }}
                   className="text-sm mt-3"
                   style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--mt-ink3)' }}
                 >
@@ -416,6 +440,9 @@ function LoginComponent() {
               </div>
 
               <GoogleLoginButton />
+              <div style={{ marginTop: 10 }}>
+                <AppleLoginButton />
+              </div>
             </div>
             )}
           </div>
@@ -424,7 +451,7 @@ function LoginComponent() {
             <img src="/brand/orb-violet.png" alt="" className={styles.rightOrb} />
             <div className={styles.rightContent}>
               <span className={styles.rightLogo} role="img" aria-label="Mitrata" />
-              {!showChooser && !verifyingEmail && !authState.requires2FA && !googleReauthAccount && (
+              {!showChooser && !verifyingEmail && !authState.requires2FA && !oauthReauthAccount && (
                 <>
                   <span>{userLoginMethod ? 'Create an account? ' : 'Already have an account? '}</span>
                   <span

--- a/frontend/src/pages/profile/index.jsx
+++ b/frontend/src/pages/profile/index.jsx
@@ -582,7 +582,11 @@ export default function Profile() {
                   <label>Email</label>
                   <input type="email" value={userProfile?.userId?.email || ''} disabled />
                   <p className={styles.fieldHint}>
-                    {userProfile?.userId?.googleId ? "Managed by your Google account" : "Contact support to change your email"}
+                    {userProfile?.userId?.googleId
+                      ? "Managed by your Google account"
+                      : userProfile?.userId?.appleId
+                        ? "Managed by your Apple ID"
+                        : "Contact support to change your email"}
                   </p>
                 </div>
                 <div className={styles.formGroup}>

--- a/frontend/src/pages/settings/index.jsx
+++ b/frontend/src/pages/settings/index.jsx
@@ -177,7 +177,7 @@ export default function Settings() {
                         sub="Name, username, bio, experience, education"
                         onClick={() => router.push('/profile')}
                     />
-                    {!user?.userId?.googleId && (
+                    {!user?.userId?.googleId && !user?.userId?.appleId && (
                         <SettingsItem
                             icon={KeyRound}
                             label="Password"

--- a/frontend/src/pages/settings/two_factor/index.jsx
+++ b/frontend/src/pages/settings/two_factor/index.jsx
@@ -14,7 +14,7 @@ export default function TwoFactorPage() {
     const dispatch = useDispatch();
     const toast = useToast();
     const { user, twoFactorEnabled } = useSelector((state) => state.auth);
-    const hasPassword = !user?.userId?.googleId;
+    const hasPassword = !user?.userId?.googleId && !user?.userId?.appleId;
 
     const [loaded, setLoaded] = useState(false);
     const [setupData, setSetupData] = useState(null); // { secret, qrCodeDataUrl }


### PR DESCRIPTION
## Summary
Mirrors the existing Google OAuth architecture rather than introducing Firebase Auth as a second identity system — the backend's own JWT/session model stays the single source of truth for both providers.

- Apple's identity token verified server-side against Apple's real public keys (no new dependency — Node's `crypto.createPublicKey` accepts JWK format directly, verified against Apple's live JWKS)
- Same session-code exchange pattern as Google (one-time code on the cross-origin callback redirect, exchanged via a same-origin proxied POST so the cookie lands correctly) — generalized (`signOAuthSessionCode`/`verifyOAuthSessionCode`) instead of duplicated
- Plain top-level redirect for the button (no JS SDK needed for Apple, unlike Google) — immune to the popup/tracking-prevention issues hit earlier with GSI
- Fixed a real gap found in the process: the CORS bypass for cross-site `form_post` callbacks was Google-only; Apple's identical callback shape needed the same exemption
- Every `googleId`-gated "no password" UI check (password field, delete-account, 2FA, quick-switch reauth) now also checks `appleId`

## Config
- `APPLE_SERVICES_ID=com.mitrata.web` set on Render
- `NEXT_PUBLIC_APPLE_SERVICES_ID=com.mitrata.web` set on Vercel
- Redirect URI already registered in Apple's portal: `https://mitrata.onrender.com/api/auth/apple/callback`

## Test plan
- [x] Real Apple JWKS fetched and converted to a usable public key via Node's built-in crypto
- [x] Full header-parse → key-lookup → RS256-verify → audience/issuer-rejection path exercised against a self-signed token shaped like Apple's real id_token; wrong-audience and wrong-issuer both correctly rejected
- [x] Unconfigured-server fallback verified locally (no crash, clean error redirect)
- [x] Backend `node --check` clean, frontend `next build` clean
- [ ] Manual end-to-end sign-in with a real Apple ID once deployed