### PR TITLE
Lowercase usernames + comment counts and edit/delete

### DIFF
--- a/backend/controllers/post.controller.js
+++ b/backend/controllers/post.controller.js
@@ -58,6 +58,25 @@ const summarise = (reactions, userId) => {
   };
 };
 
+// One aggregate query for however many posts are being returned, not one
+// countDocuments per post — the feed/profile-posts endpoints return a whole
+// page at once, and N+1 comment-count queries would be the same mistake the
+// N+1 audit already caught elsewhere in this codebase (see connection
+// requests). Only ever called on an already-paginated slice (~20 posts),
+// never the full ranking pool.
+const attachCommentCounts = async (posts) => {
+  if (posts.length === 0) return posts;
+  const counts = await Comment.aggregate([
+    { $match: { post_Id: { $in: posts.map((p) => p._id) } } },
+    { $group: { _id: "$post_Id", count: { $sum: 1 } } },
+  ]);
+  const countByPostId = new Map(counts.map((c) => [c._id.toString(), c.count]));
+  return posts.map((post) => ({
+    ...post,
+    commentCount: countByPostId.get(post._id.toString()) || 0,
+  }));
+};
+
 export const activecheck = async (req, res) => {
   return res.status(200).json({ message: "Running route post" });
 };
@@ -190,7 +209,7 @@ export const getAllPosts = async (req, res) => {
     const paginatedPosts = scoredPosts.slice(skip, skip + limit);
 
     // Remove internal score from response
-    const formattedPosts = paginatedPosts.map(({ _score, ...post }) => post);
+    const formattedPosts = await attachCommentCounts(paginatedPosts.map(({ _score, ...post }) => post));
 
     const effectiveTotal = Math.min(totalMatching, RANKING_POOL_SIZE);
 
@@ -256,10 +275,10 @@ export const getPostsByUsername = async (req, res) => {
       Post.countDocuments(query)
     ]);
 
-    const formattedPosts = posts.map((post) => ({
+    const formattedPosts = await attachCommentCounts(posts.map((post) => ({
       ...post,
       ...summarise(post.reactions, requesterId),
-    }));
+    })));
 
     return res.status(200).json({
       posts: formattedPosts,
@@ -353,6 +372,33 @@ export const getComment_by_Post = async (req, res) => {
       .lean();
 
     return res.status(200).json({ comments });
+  } catch (error) {
+    return res.status(500).json({ message: error.message });
+  }
+};
+
+export const editComment = async (req, res) => {
+  const { comment_id, commentBody } = req.body;
+  try {
+    if (!commentBody || !commentBody.trim()) {
+      return res.status(400).json({ message: "Comment body is required" });
+    }
+
+    const comment = await Comment.findOne({ _id: comment_id });
+    if (!comment) return res.status(400).json({ message: "Comment not found" });
+
+    // Same ownership rule as delete — only the author can edit their own
+    // comment, checked the same way.
+    if (comment.userId.toString() !== req.userId.toString()) {
+      return res.status(403).json({ message: "Unauthorized — not your comment" });
+    }
+
+    comment.body = commentBody.trim();
+    comment.edited = true;
+    await comment.save();
+    await comment.populate("userId", "username name profilePicture");
+
+    return res.status(200).json({ message: "comment updated", comment });
   } catch (error) {
     return res.status(500).json({ message: error.message });
   }
@@ -567,11 +613,11 @@ export const getBookmarkedPosts = async (req, res) => {
       .limit(300)
       .lean();
 
-    const formatted = posts.map((post) => ({
+    const formatted = await attachCommentCounts(posts.map((post) => ({
       ...post,
       ...summarise(post.reactions, req.userId),
       bookmarked: true,
-    }));
+    })));
 
     return res.status(200).json({ posts: formatted });
   } catch (error) {
@@ -635,10 +681,10 @@ export const getLikedPosts = async (req, res) => {
       .limit(300)
       .lean();
 
-    const formatted = posts.map((post) => ({
+    const formatted = await attachCommentCounts(posts.map((post) => ({
       ...post,
       ...summarise(post.reactions, userId),
-    }));
+    })));
 
     return res.status(200).json({ posts: formatted });
   } catch (error) {

--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -57,13 +57,19 @@ export const register = async (req, res) => {
         if (!usernameRegex.test(username)) {
             return res.status(400).json({ message: "Username must be 3-30 characters, alphanumeric and underscores only" });
         }
+        // Lowercased before anything else touches it — otherwise "JohnDoe"
+        // and "johndoe" pass the uniqueness check below as two different
+        // values (Mongo string comparison is case-sensitive) and register as
+        // separate accounts, and whatever case someone happened to type
+        // becomes permanent everywhere it's displayed.
+        const normalizedUsername = username.toLowerCase();
 
         const user = await User.findOne({ email });
         if (user) {
             return res.status(400).json({ message: "User already exists" });
         }
 
-        const existingUsername = await User.findOne({ username });
+        const existingUsername = await User.findOne({ username: normalizedUsername });
         if (existingUsername) {
             return res.status(400).json({ message: "Username already taken" });
         }
@@ -73,7 +79,7 @@ export const register = async (req, res) => {
             name,
             email,
             password: HashedPassword,
-            username
+            username: normalizedUsername
         })
         await newUser.save();
         const profile = new Profile({
@@ -355,7 +361,7 @@ const verifyAndUpsertGoogleUser = async (idToken) => {
 
     let user = await User.findOne({ email: payload.email });
     if (!user) {
-        const usernameBase = payload.email.split("@")[0].replace(/[^a-zA-Z0-9_]/g, "");
+        const usernameBase = payload.email.split("@")[0].replace(/[^a-zA-Z0-9_]/g, "").toLowerCase();
         let username = usernameBase;
         let suffix = 0;
         while (await User.findOne({ username })) {
@@ -525,7 +531,7 @@ const verifyAndUpsertAppleUser = async (idToken, appleUserJson) => {
 
     let user = await User.findOne({ $or: [{ appleId: payload.sub }, { email: payload.email }] });
     if (!user) {
-        const usernameBase = (payload.email || `apple${payload.sub}`).split("@")[0].replace(/[^a-zA-Z0-9_]/g, "");
+        const usernameBase = (payload.email || `apple${payload.sub}`).split("@")[0].replace(/[^a-zA-Z0-9_]/g, "").toLowerCase();
         let username = usernameBase;
         let suffix = 0;
         while (await User.findOne({ username })) {
@@ -829,14 +835,19 @@ export const updateAccountSettings = async (req, res) => {
         const user = await User.findById(req.userId);
         if (!user) return res.status(404).json({ message: "User not found" });
 
-        if (username !== undefined && username !== user.username) {
+        if (username !== undefined) {
             const usernameRegex = /^[a-zA-Z0-9_]{3,30}$/;
             if (!usernameRegex.test(username)) {
                 return res.status(400).json({ message: "Username must be 3-30 characters, alphanumeric and underscores only" });
             }
-            const taken = await User.findOne({ username, _id: { $ne: user._id } });
-            if (taken) return res.status(400).json({ message: "Username already taken" });
-            user.username = username;
+            // Lowercased before the "did it actually change" / uniqueness
+            // checks — same reasoning as register's normalizedUsername.
+            const normalizedUsername = username.toLowerCase();
+            if (normalizedUsername !== user.username) {
+                const taken = await User.findOne({ username: normalizedUsername, _id: { $ne: user._id } });
+                if (taken) return res.status(400).json({ message: "Username already taken" });
+                user.username = normalizedUsername;
+            }
         }
 
         if (isPrivate !== undefined) user.isPrivate = !!isPrivate;

--- a/backend/models/comments.model.js
+++ b/backend/models/comments.model.js
@@ -18,6 +18,10 @@ const commentSchema=new mongoose.Schema({
     body:{
         type:String,
         required:true
+    },
+    edited: {
+        type: Boolean,
+        default: false
     }
 
 // getComment_by_Post sorts by createdAt — without { timestamps: true } that

--- a/backend/models/users.model.js
+++ b/backend/models/users.model.js
@@ -9,7 +9,14 @@ const userSchema = new mongoose.Schema({
     username: {
         type: String,
         required: true,
-        unique: true
+        unique: true,
+        // Backstop, not the primary fix — the actual normalization happens
+        // in the controllers before the uniqueness check runs (this alone
+        // wouldn't stop "JohnDoe" and "johndoe" both getting through as
+        // "different" values right up until save). This just guarantees any
+        // future write path that forgets to normalize still ends up
+        // lowercase in the database.
+        lowercase: true
     },
     email: {
         type: String,

--- a/backend/routes/post.routes.js
+++ b/backend/routes/post.routes.js
@@ -1,6 +1,6 @@
 
 import { Router } from "express";
-import { activecheck, commentPost, createPost, delete_Comments, deletePost, getAllPosts, getBookmarkedPosts, getComment_by_Post, getLikedPosts, getPostAnalytics, getPostById, getPostsByUsername, getPublicStats, getTrendingTags, reactToComplaint, toggleBookmark } from "../controllers/post.controller.js";
+import { activecheck, commentPost, createPost, delete_Comments, deletePost, editComment, getAllPosts, getBookmarkedPosts, getComment_by_Post, getLikedPosts, getPostAnalytics, getPostById, getPostsByUsername, getPublicStats, getTrendingTags, reactToComplaint, toggleBookmark } from "../controllers/post.controller.js";
 import { verifyToken } from "../middleware/auth.middleware.js";
 import multer from "multer";
 import { Storage } from "../config/cloudinary.js";
@@ -26,6 +26,7 @@ router.route('/delete_post').post(verifyToken, deletePost);
 router.route('/comment_post').post(verifyToken, commentPost);
 router.route('/getcomment_by_post').get(verifyToken, getComment_by_Post);
 router.route('/delete_comments').delete(verifyToken, delete_Comments);
+router.route('/edit_comment').patch(verifyToken, editComment);
 router.route('/react/:id').post(verifyToken, reactToComplaint);
 
 // Analytics route

--- a/frontend/src/config/redux/action/postAction/index.js
+++ b/frontend/src/config/redux/action/postAction/index.js
@@ -170,12 +170,39 @@ export const commentPost = createAsyncThunk(
             })
             thunkapi.dispatch(getAllComments({ postId }));
             if (response.status === 200) {
-                return thunkapi.fulfillWithValue("Comment added successfully")
+                return thunkapi.fulfillWithValue({ postId })
             } else {
                 return thunkapi.rejectWithValue("Comment not added")
             }
         } catch (error) {
             return thunkapi.rejectWithValue(error.response?.data || { message: "Comment failed" })
+        }
+    }
+)
+
+export const editComment = createAsyncThunk(
+    'post/editComment',
+    async ({ commentId, commentBody }, thunkapi) => {
+        try {
+            const response = await clientServer.patch('/edit_comment', {
+                comment_id: commentId,
+                commentBody
+            })
+            return thunkapi.fulfillWithValue(response.data.comment)
+        } catch (error) {
+            return thunkapi.rejectWithValue(error.response?.data || { message: "Failed to edit comment" })
+        }
+    }
+)
+
+export const deleteComment = createAsyncThunk(
+    'post/deleteComment',
+    async ({ commentId, postId }, thunkapi) => {
+        try {
+            await clientServer.delete('/delete_comments', { data: { comment_id: commentId } })
+            return thunkapi.fulfillWithValue({ commentId, postId })
+        } catch (error) {
+            return thunkapi.rejectWithValue(error.response?.data || { message: "Failed to delete comment" })
         }
     }
 )

--- a/frontend/src/config/redux/reducer/postReducer/index.js
+++ b/frontend/src/config/redux/reducer/postReducer/index.js
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { commentPost, createPost, getAllComments, getAllPosts, getBookmarkedPosts, getLikedPosts, getPostsByUsername, reactToPost, toggleBookmark } from '../../action/postAction';
+import { commentPost, createPost, deleteComment, editComment, getAllComments, getAllPosts, getBookmarkedPosts, getLikedPosts, getPostsByUsername, reactToPost, toggleBookmark } from '../../action/postAction';
 
 
 
@@ -90,9 +90,17 @@ const postSlice = createSlice({
                 // Keep postId until fulfillment/rejection to prevent modal flicker
             })
             .addCase(commentPost.fulfilled, (state, action) => {
-                state.message = action.payload
                 state.isLoading = false
                 state.isError = false
+                // The count badge next to the comment icon (post.commentCount)
+                // — getAllComments (also dispatched by this thunk) refreshes
+                // the open modal's list, but that's a different array and
+                // wouldn't touch the count sitting on the post itself.
+                const { postId } = action.payload;
+                for (const list of [state.posts, state.userPosts]) {
+                    const post = list.find((p) => p._id === postId);
+                    if (post) post.commentCount = (post.commentCount || 0) + 1;
+                }
             })
             .addCase(commentPost.rejected, (state, action) => {
                 state.message = action.payload
@@ -100,6 +108,27 @@ const postSlice = createSlice({
                 state.isError = true
             }
             )
+            .addCase(editComment.fulfilled, (state, action) => {
+                const updated = action.payload;
+                const idx = state.comments.findIndex((c) => c._id === updated._id);
+                if (idx !== -1) state.comments[idx] = updated;
+            })
+            .addCase(editComment.rejected, (state, action) => {
+                state.message = action.payload?.message
+                state.isError = true
+            })
+            .addCase(deleteComment.fulfilled, (state, action) => {
+                const { commentId, postId } = action.payload;
+                state.comments = state.comments.filter((c) => c._id !== commentId);
+                for (const list of [state.posts, state.userPosts]) {
+                    const post = list.find((p) => p._id === postId);
+                    if (post) post.commentCount = Math.max(0, (post.commentCount || 1) - 1);
+                }
+            })
+            .addCase(deleteComment.rejected, (state, action) => {
+                state.message = action.payload?.message
+                state.isError = true
+            })
             .addCase(reactToPost.fulfilled, (state, action) => {
                 // Patch the single post in place — no full refetch needed,
                 // this is the same data getAllPosts already returns per-post.

--- a/frontend/src/pages/activity/[username].jsx
+++ b/frontend/src/pages/activity/[username].jsx
@@ -7,14 +7,14 @@ import ReportMenu from '@/Components/ReportMenu';
 import EmptyState from '@/Components/ui/EmptyState';
 import PageLoader from '@/Components/ui/PageLoader';
 import BlastLoader from '@/Components/ui/BlastLoader';
-import { getPostsByUsername, deletePost, reactToPost, getAllComments, commentPost, toggleBookmark } from '@/config/redux/action/postAction';
+import { getPostsByUsername, deletePost, reactToPost, getAllComments, commentPost, editComment, deleteComment, toggleBookmark } from '@/config/redux/action/postAction';
 import { resetPostId } from '@/config/redux/reducer/postReducer';
 import { Base_Url } from '@/config';
 import { useToast } from '@/Components/Toast';
 import {
     ArrowLeft, Trash2, X, FileText,
     Heart, Flame, HandHeart, Lightbulb,
-    MessageCircle, Share2, Bookmark,
+    MessageCircle, Share2, Bookmark, Pencil, Check,
 } from 'lucide-react';
 
 // Same reaction set as the dashboard feed — this page shows the identical
@@ -92,13 +92,48 @@ export default function UserActivityPage() {
 
     const handleCommentSubmit = async () => {
         if (!commentText.trim()) return;
+        // commentPost's own thunk body already dispatches getAllComments to
+        // refresh the open modal, and its reducer case increments the post's
+        // commentCount directly — the extra getAllComments call and a full
+        // refreshData() (refetching this user's whole post list for one
+        // count) were both redundant on top of that.
         await dispatch(commentPost({
             postId: postState.postId,
             commentBody: commentText.trim()
         }));
         setCommentText("");
-        dispatch(getAllComments({ postId: postState.postId }));
-        refreshData();
+    };
+
+    const [editingCommentId, setEditingCommentId] = useState(null);
+    const [editCommentText, setEditCommentText] = useState("");
+
+    const handleStartEditComment = (comment) => {
+        setEditingCommentId(comment._id);
+        setEditCommentText(comment.body);
+    };
+
+    const handleCancelEditComment = () => {
+        setEditingCommentId(null);
+        setEditCommentText("");
+    };
+
+    const handleSaveEditComment = async () => {
+        if (!editCommentText.trim()) return;
+        const result = await dispatch(editComment({ commentId: editingCommentId, commentBody: editCommentText.trim() }));
+        if (editComment.fulfilled.match(result)) {
+            setEditingCommentId(null);
+            setEditCommentText("");
+        } else {
+            toast.error(result.payload?.message || "Failed to edit comment");
+        }
+    };
+
+    const handleDeleteComment = async (comment) => {
+        if (!window.confirm("Delete this comment?")) return;
+        const result = await dispatch(deleteComment({ commentId: comment._id, postId: postState.postId }));
+        if (!deleteComment.fulfilled.match(result)) {
+            toast.error(result.payload?.message || "Failed to delete comment");
+        }
     };
 
     const handleShare = (postId) => {
@@ -214,6 +249,7 @@ export default function UserActivityPage() {
                                     <div className={styles.actionGroup}>
                                         <div className={styles.actionBtn} onClick={() => dispatch(getAllComments({ postId: post._id }))}>
                                             <MessageCircle size={17} strokeWidth={1.8} />
+                                            {post.commentCount > 0 && <span>{post.commentCount}</span>}
                                         </div>
                                         <div className={styles.actionBtn} onClick={() => handleShare(post._id)}>
                                             <Share2 size={17} strokeWidth={1.8} />
@@ -245,19 +281,47 @@ export default function UserActivityPage() {
                             {postState.comments?.length === 0 ? (
                                 <p className={styles.noCommentsText}>No comments yet.</p>
                             ) : (
-                                [...postState.comments].reverse().map((item, i) => (
-                                    <div key={i} className={styles.singleCommentContainer}>
-                                        <img
-                                            className={styles.commentAvatar}
-                                            src={item?.userId?.profilePicture || "/default-avatar.svg"}
-                                            alt="avatar"
-                                        />
-                                        <div className={styles.singleComment}>
-                                            <span className={styles.commentUser}>{item?.userId?.username || "User"}</span>
-                                            <p className={styles.commentMsg}>{item.body}</p>
+                                [...postState.comments].reverse().map((item, i) => {
+                                    const isOwnComment = item?.userId?._id === authState.user?.userId?._id;
+                                    const isEditing = editingCommentId === item._id;
+                                    return (
+                                        <div key={i} className={styles.singleCommentContainer}>
+                                            <img
+                                                className={styles.commentAvatar}
+                                                src={item?.userId?.profilePicture || "/default-avatar.svg"}
+                                                alt="avatar"
+                                            />
+                                            <div className={styles.singleComment} style={{ flex: 1 }}>
+                                                <span className={styles.commentUser}>{item?.userId?.username || "User"}</span>
+                                                {isEditing ? (
+                                                    <div style={{ display: "flex", gap: 6, alignItems: "center", marginTop: 4 }}>
+                                                        <input
+                                                            type="text"
+                                                            value={editCommentText}
+                                                            onChange={(e) => setEditCommentText(e.target.value)}
+                                                            onKeyDown={(e) => e.key === "Enter" && handleSaveEditComment()}
+                                                            autoFocus
+                                                            style={{ flex: 1, minWidth: 0 }}
+                                                        />
+                                                        <Check size={16} style={{ cursor: "pointer", flexShrink: 0 }} onClick={handleSaveEditComment} />
+                                                        <X size={16} style={{ cursor: "pointer", flexShrink: 0 }} onClick={handleCancelEditComment} />
+                                                    </div>
+                                                ) : (
+                                                    <p className={styles.commentMsg}>
+                                                        {item.body}
+                                                        {item.edited && <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 6 }}>(edited)</span>}
+                                                    </p>
+                                                )}
+                                            </div>
+                                            {isOwnComment && !isEditing && (
+                                                <div style={{ display: "flex", gap: 8, flexShrink: 0, alignSelf: "flex-start" }}>
+                                                    <Pencil size={14} style={{ cursor: "pointer", opacity: 0.7 }} onClick={() => handleStartEditComment(item)} />
+                                                    <Trash2 size={14} style={{ cursor: "pointer", opacity: 0.7 }} onClick={() => handleDeleteComment(item)} />
+                                                </div>
+                                            )}
                                         </div>
-                                    </div>
-                                ))
+                                    );
+                                })
                             )}
                         </div>
                         <div className={styles.commentInputBar}>

--- a/frontend/src/pages/dashboard/index.jsx
+++ b/frontend/src/pages/dashboard/index.jsx
@@ -3,7 +3,9 @@ import { useToast } from "@/Components/Toast";
 import {
   commentPost,
   createPost,
+  deleteComment,
   deletePost,
+  editComment,
   getAllComments,
   getAllPosts,
   reactToPost,
@@ -41,6 +43,8 @@ import {
   Bookmark,
   X,
   Plus,
+  Pencil,
+  Check,
 } from "lucide-react";
 
 const REACTIONS = [
@@ -253,6 +257,11 @@ export default function Dashboard() {
     if (!commentText.trim()) return;
     setIsCommenting(true);
     try {
+      // commentPost's own thunk body already dispatches getAllComments to
+      // refresh the open modal, and its reducer case increments the post's
+      // commentCount directly — a second getAllComments call and a full
+      // handleRefresh() (refetching the entire feed just to reflect one
+      // post's new count) were both redundant on top of that.
       await dispatch(
         commentPost({
           postId: postState.postId,
@@ -260,10 +269,40 @@ export default function Dashboard() {
         })
       );
       setCommentText("");
-      await dispatch(getAllComments({ postId: postState.postId }));
-      handleRefresh(); // Updates the comment count on the main card
     } finally {
       setIsCommenting(false);
+    }
+  };
+
+  const [editingCommentId, setEditingCommentId] = useState(null);
+  const [editCommentText, setEditCommentText] = useState("");
+
+  const handleStartEditComment = (comment) => {
+    setEditingCommentId(comment._id);
+    setEditCommentText(comment.body);
+  };
+
+  const handleCancelEditComment = () => {
+    setEditingCommentId(null);
+    setEditCommentText("");
+  };
+
+  const handleSaveEditComment = async () => {
+    if (!editCommentText.trim()) return;
+    const result = await dispatch(editComment({ commentId: editingCommentId, commentBody: editCommentText.trim() }));
+    if (editComment.fulfilled.match(result)) {
+      setEditingCommentId(null);
+      setEditCommentText("");
+    } else {
+      toast.error(result.payload?.message || "Failed to edit comment");
+    }
+  };
+
+  const handleDeleteComment = async (comment) => {
+    if (!window.confirm("Delete this comment?")) return;
+    const result = await dispatch(deleteComment({ commentId: comment._id, postId: postState.postId }));
+    if (!deleteComment.fulfilled.match(result)) {
+      toast.error(result.payload?.message || "Failed to delete comment");
     }
   };
 
@@ -672,6 +711,7 @@ export default function Dashboard() {
                           className={styles.actionBtn}
                         >
                           <MessageCircle />
+                          {post.commentCount > 0 && <span>{post.commentCount}</span>}
                         </div>
 
                         {/* SHARE */}
@@ -743,6 +783,8 @@ export default function Dashboard() {
                   {/* Reverse comments list for newest first display (if API doesn't do it) */}
                   {postState.comments?.length > 0 &&
                     [...postState.comments].reverse().map((item, i) => {
+                      const isOwnComment = item?.userId?._id === authState.user?.userId?._id;
+                      const isEditing = editingCommentId === item._id;
                       return (
                         <div key={i} className={styles.singleCommentContainer}>
                           {" "}
@@ -754,12 +796,39 @@ export default function Dashboard() {
                             alt={`${item?.userId?.username}'s profile`}
                           />
                           {/* 2. Comment Content */}
-                          <div className={styles.singleComment}>
+                          <div className={styles.singleComment} style={{ flex: 1 }}>
                             <span className={styles.commentUser}>
                               {item?.userId?.username || "User"}
                             </span>
-                            <p className={styles.commentMsg}>{item.body}</p>
+                            {isEditing ? (
+                              <div style={{ display: "flex", gap: 6, alignItems: "center", marginTop: 4 }}>
+                                <input
+                                  type="text"
+                                  value={editCommentText}
+                                  onChange={(e) => setEditCommentText(e.target.value)}
+                                  onKeyDown={(e) => e.key === "Enter" && handleSaveEditComment()}
+                                  autoFocus
+                                  style={{ flex: 1, minWidth: 0 }}
+                                />
+                                <Check size={16} style={{ cursor: "pointer", flexShrink: 0 }} onClick={handleSaveEditComment} />
+                                <X size={16} style={{ cursor: "pointer", flexShrink: 0 }} onClick={handleCancelEditComment} />
+                              </div>
+                            ) : (
+                              <p className={styles.commentMsg}>
+                                {item.body}
+                                {item.edited && (
+                                  <span style={{ fontSize: 11, opacity: 0.6, marginLeft: 6 }}>(edited)</span>
+                                )}
+                              </p>
+                            )}
                           </div>
+                          {/* Own comments only — edit/delete */}
+                          {isOwnComment && !isEditing && (
+                            <div style={{ display: "flex", gap: 8, flexShrink: 0, alignSelf: "flex-start" }}>
+                              <Pencil size={14} style={{ cursor: "pointer", opacity: 0.7 }} onClick={() => handleStartEditComment(item)} />
+                              <Trash2 size={14} style={{ cursor: "pointer", opacity: 0.7 }} onClick={() => handleDeleteComment(item)} />
+                            </div>
+                          )}
                         </div>
                       );
                     })}

--- a/frontend/src/pages/login/index.jsx
+++ b/frontend/src/pages/login/index.jsx
@@ -184,8 +184,11 @@ function LoginComponent() {
       setUsernameError("");
     }
 
-    // Strictly remove all spaces immediately
-    const sanitizedValue = val.replace(/\s/g, "");
+    // Strictly remove all spaces immediately, and lowercase as you type —
+    // the backend normalizes anyway (see register's normalizedUsername), but
+    // showing "JohnDoe" for a moment then having it become "johndoe" only
+    // after submit reads as a bug. This way what you see is what gets saved.
+    const sanitizedValue = val.replace(/\s/g, "").toLowerCase();
     setUsername(sanitizedValue);
   };
 

--- a/frontend/src/pages/profile/index.jsx
+++ b/frontend/src/pages/profile/index.jsx
@@ -572,7 +572,11 @@ export default function Profile() {
                     value={formData.username}
                     onChange={(e) => {
                       setUsernameError("");
-                      updateForm({ ...formData, username: e.target.value.replace(/\s/g, '') });
+                      // Lowercased as you type — the backend normalizes
+                      // regardless (see updateAccountSettings), but showing
+                      // "JohnDoe" only to have it silently become "johndoe"
+                      // after save reads as a bug, not a feature.
+                      updateForm({ ...formData, username: e.target.value.replace(/\s/g, '').toLowerCase() });
                     }}
                     placeholder="username"
                   />


### PR DESCRIPTION
## Summary

**Username casing** — root-caused to the signup/update validation regex allowing uppercase (not a CSS bug). Normalized to lowercase at every write path (register, updateAccountSettings, Google/Apple OAuth username generation) plus a schema-level `lowercase: true` backstop. Frontend inputs lowercase as you type. Existing accounts aren't retroactively renamed (avoids case-collision risk with already-registered distinct-case usernames) — this stops new ones going forward, as asked.

**Comment counts** — genuinely missing from every post-listing endpoint (`getAllPosts`, `getPostsByUsername`, `getLikedPosts`, `getBookmarkedPosts`); the comment icon had no count to show. Added via one aggregate query per page of results, not per-post.

**Edit/delete comments** — delete already existed on the backend with no frontend wiring at all; added a new `editComment` endpoint (same ownership check as delete) plus full UI (pencil/trash icons, inline edit, "(edited)" tag) on both the dashboard and activity page comment modals.

**Also cleaned up**: found and removed real redundancy while in this code — commenting was calling `getAllComments` twice and doing a full feed refetch just to reflect one count; now the reducer patches it directly.

## Test plan
- [x] Verified live against a real backend: comment count appears correctly in the feed, edit sets `edited:true`, delete brings count back to 0
- [x] Editing/deleting someone else's comment correctly rejected with 403
- [x] `npx next build` clean, backend `node --check` clean on all touched files