### PR TITLE
Add first-login onboarding page

### DIFF
--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -79,7 +79,13 @@ export const register = async (req, res) => {
             name,
             email,
             password: HashedPassword,
-            username: normalizedUsername
+            username: normalizedUsername,
+            // Regular signup already collects name/username explicitly, unlike
+            // Google/Apple's auto-generated values — but nobody gets asked for
+            // a profile photo at signup either way, and the onboarding page
+            // covers that for every account the same way rather than only
+            // the OAuth ones.
+            onboarded: false
         })
         await newUser.save();
         const profile = new Profile({
@@ -375,7 +381,11 @@ const verifyAndUpsertGoogleUser = async (idToken) => {
             googleId: payload.sub,
             profilePicture: (await rehostGoogleAvatar(payload.picture)) || undefined,
             // Google already verified this address — no OTP step needed.
-            emailVerified: true
+            emailVerified: true,
+            // name/username are auto-generated from the Google profile, not
+            // chosen by the user — send them through the mobile onboarding
+            // page to actually pick both (and a photo) before their first feed load.
+            onboarded: false
         });
         await user.save();
         await new Profile({ userId: user._id }).save();
@@ -544,7 +554,12 @@ const verifyAndUpsertAppleUser = async (idToken, appleUserJson) => {
             username,
             appleId: payload.sub,
             // Apple already verified this address — no OTP step needed.
-            emailVerified: true
+            emailVerified: true,
+            // name/username are auto-generated (Apple only sends a real name
+            // on the very first authorization, and even then not always) —
+            // send them through the mobile onboarding page to actually pick
+            // both (and a photo) before their first feed load.
+            onboarded: false
         });
         await user.save();
         await new Profile({ userId: user._id }).save();
@@ -831,9 +846,15 @@ export const updateUserProfile = async (req, res) => {
 // Profile document's fields.
 export const updateAccountSettings = async (req, res) => {
     try {
-        const { username, isPrivate, pushEnabled, quietHours } = req.body;
+        const { name, username, isPrivate, pushEnabled, quietHours, onboarded } = req.body;
         const user = await User.findById(req.userId);
         if (!user) return res.status(404).json({ message: "User not found" });
+
+        if (name !== undefined) {
+            const trimmed = String(name).trim();
+            if (!trimmed) return res.status(400).json({ message: "Name cannot be empty" });
+            user.name = trimmed.slice(0, 60);
+        }
 
         if (username !== undefined) {
             const usernameRegex = /^[a-zA-Z0-9_]{3,30}$/;
@@ -852,6 +873,7 @@ export const updateAccountSettings = async (req, res) => {
 
         if (isPrivate !== undefined) user.isPrivate = !!isPrivate;
         if (pushEnabled !== undefined) user.pushEnabled = !!pushEnabled;
+        if (onboarded !== undefined) user.onboarded = !!onboarded;
 
         if (quietHours !== undefined) {
             const timeRegex = /^([01]\d|2[0-3]):[0-5]\d$/;
@@ -870,10 +892,12 @@ export const updateAccountSettings = async (req, res) => {
         await user.save();
         return res.json({
             message: "Updated successfully!",
+            name: user.name,
             isPrivate: user.isPrivate,
             pushEnabled: user.pushEnabled,
             username: user.username,
-            quietHours: user.quietHours
+            quietHours: user.quietHours,
+            onboarded: user.onboarded
         });
     } catch (error) {
         if (error.code === 11000) {
@@ -943,7 +967,7 @@ export const getUserAndProfile = async (req, res) => {
         // req.userId is already a verified-to-exist user (see verifyToken) —
         // no need to re-fetch the User doc just to read its own id back.
         const userProfile = await Profile.findOne({ userId: req.userId })
-            .populate("userId", "name email username profilePicture coverPhoto createAt role googleId appleId isPrivate pushEnabled quietHours");
+            .populate("userId", "name email username profilePicture coverPhoto createAt role googleId appleId isPrivate pushEnabled quietHours onboarded");
 
         if (!userProfile) {
             return res.status(404).json({ message: "profile not found" });

--- a/backend/models/users.model.js
+++ b/backend/models/users.model.js
@@ -105,6 +105,17 @@ const userSchema = new mongoose.Schema({
         end: { type: String, default: "07:00" },
         timezone: { type: String, default: "UTC" },
     },
+    // Whether the one-time "add your name/username/photo" onboarding page
+    // has been completed. Defaults true — Mongoose applies schema defaults
+    // during hydration even for documents that predate this field, so
+    // defaulting false here would retroactively force onboarding onto every
+    // existing account. Only user-creation code paths (register,
+    // verifyAndUpsertGoogleUser, verifyAndUpsertAppleUser) explicitly set
+    // this to false for genuinely brand-new accounts.
+    onboarded: {
+        type: Boolean,
+        default: true
+    },
     // TOTP two-step verification. `secret` holds a pending (unconfirmed)
     // secret while the user is mid-setup, and the confirmed one once
     // `enabled`. `select: false` keeps these out of any query that doesn't

--- a/frontend/src/config/redux/reducer/authReducer/index.js
+++ b/frontend/src/config/redux/reducer/authReducer/index.js
@@ -270,6 +270,7 @@ const authSlice = createSlice({
                     if (action.payload.isPrivate !== undefined) state.user.userId.isPrivate = action.payload.isPrivate;
                     if (action.payload.pushEnabled !== undefined) state.user.userId.pushEnabled = action.payload.pushEnabled;
                     if (action.payload.quietHours !== undefined) state.user.userId.quietHours = action.payload.quietHours;
+                    if (action.payload.onboarded !== undefined) state.user.userId.onboarded = action.payload.onboarded;
                 }
             })
             .addCase(getBlockedUsers.fulfilled, (state, action) => {

--- a/frontend/src/layout/DashboardLayout/index.jsx
+++ b/frontend/src/layout/DashboardLayout/index.jsx
@@ -63,6 +63,17 @@ export default function DashboardLayout({ children, fullWidth = false }) {
         }
     }, []);
 
+    // A brand new account (see users.model.js's `onboarded` field) hasn't
+    // picked a real name/username/photo yet — every page using this layout
+    // routes through here, so this is the one place that needs to know
+    // about it rather than every page checking individually.
+    useEffect(() => {
+        const user = authState.user?.userId;
+        if (user && user.onboarded === false && router.pathname !== '/onboarding') {
+            router.push('/onboarding');
+        }
+    }, [authState.user, router.pathname]);
+
     useEffect(() => {
         clientServer.get('/trending/tags', { params: { limit: 5 } })
             .then(({ data }) => setTrendingTags(data.tags || []))

--- a/frontend/src/pages/onboarding/index.jsx
+++ b/frontend/src/pages/onboarding/index.jsx
@@ -1,0 +1,209 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/router';
+import { useDispatch, useSelector } from 'react-redux';
+import { getAboutUser, updateUserProfile, updateAccountSettings } from '@/config/redux/action/authAction';
+import { clientServer } from '@/config';
+import { compressImage } from '@/utils/imageProcessing';
+import { useToast } from '@/Components/Toast';
+import PageLoader from '@/Components/ui/PageLoader';
+import Button from '@/Components/ui/Button';
+import { Camera } from 'lucide-react';
+import styles from './styles.module.css';
+
+const USERNAME_REGEX = /^[a-zA-Z0-9_]{3,30}$/;
+
+// One-time "finish setting up your account" page — the first thing a brand
+// new account sees (see users.model.js's `onboarded` field and
+// DashboardLayout's redirect gate). Standalone, not wrapped in
+// DashboardLayout: there's no sidebar/nav worth showing before this is done,
+// same reasoning /login stays standalone.
+export default function OnboardingPage() {
+    const router = useRouter();
+    const dispatch = useDispatch();
+    const toast = useToast();
+    const authState = useSelector((state) => state.auth);
+    const fileInputRef = useRef(null);
+
+    const [checking, setChecking] = useState(true);
+    const [name, setName] = useState('');
+    const [username, setUsername] = useState('');
+    const [usernameError, setUsernameError] = useState('');
+    const [avatarFile, setAvatarFile] = useState(null);
+    const [avatarPreview, setAvatarPreview] = useState(null);
+    const [saving, setSaving] = useState(false);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+        if (!localStorage.getItem('token')) {
+            router.replace('/login');
+            return;
+        }
+        if (!authState.user) dispatch(getAboutUser());
+    }, []);
+
+    useEffect(() => {
+        const user = authState.user?.userId;
+        if (!user) return;
+        // Already done — landing here directly (bookmark, back button)
+        // shouldn't re-run onboarding.
+        if (user.onboarded) {
+            router.replace('/dashboard');
+            return;
+        }
+        setName(user.name || '');
+        setUsername(user.username || '');
+        setAvatarPreview(user.profilePicture || null);
+        setChecking(false);
+    }, [authState.user]);
+
+    // Revoke the object URL when it's replaced or the page unmounts — it's
+    // otherwise held in memory for as long as the tab stays open.
+    useEffect(() => {
+        return () => {
+            if (avatarPreview?.startsWith('blob:')) URL.revokeObjectURL(avatarPreview);
+        };
+    }, [avatarPreview]);
+
+    const handleAvatarPick = (e) => {
+        const file = e.target.files?.[0];
+        e.target.value = '';
+        if (!file) return;
+        setAvatarFile(file);
+        setAvatarPreview(URL.createObjectURL(file));
+    };
+
+    const handleUsernameChange = (e) => {
+        setUsernameError('');
+        setUsername(e.target.value.replace(/\s/g, '').toLowerCase());
+    };
+
+    const handleContinue = async () => {
+        if (saving) return;
+        if (!name.trim()) {
+            toast.error('Please enter your name');
+            return;
+        }
+        if (!USERNAME_REGEX.test(username)) {
+            setUsernameError('3-30 characters, letters, numbers, and underscores only');
+            return;
+        }
+
+        setSaving(true);
+        try {
+            if (avatarFile) {
+                const compressed = await compressImage(avatarFile, { maxWidthOrHeight: 600, quality: 0.85 });
+                const formData = new FormData();
+                formData.append('profilePicture', compressed);
+                await clientServer.post('/user/update_profile_picture', formData, {
+                    headers: { 'Content-Type': 'multipart/form-data' },
+                });
+            }
+
+            const profileResult = await dispatch(updateUserProfile({ name: name.trim() }));
+            if (!updateUserProfile.fulfilled.match(profileResult)) {
+                toast.error(profileResult.payload?.message || 'Failed to save your name');
+                setSaving(false);
+                return;
+            }
+
+            const settingsResult = await dispatch(updateAccountSettings({ username, onboarded: true }));
+            if (!updateAccountSettings.fulfilled.match(settingsResult)) {
+                setUsernameError(settingsResult.payload?.message || 'Username already taken');
+                setSaving(false);
+                return;
+            }
+
+            await dispatch(getAboutUser());
+            router.push('/dashboard');
+        } catch (error) {
+            toast.error('Something went wrong — please try again');
+            setSaving(false);
+        }
+    };
+
+    if (checking) return <PageLoader />;
+
+    return (
+        <div className={styles.container}>
+            <div className={styles.cardContainer}>
+                <div className={styles.cardContainer_left}>
+                    <span className={styles.brandMark} role="img" aria-label="Mitrata" />
+                    <h1 className={styles.heading}>Welcome to Mitrata</h1>
+                    <p className={styles.subheading}>
+                        Let's finish setting up your account — you can always change this later in Settings.
+                    </p>
+
+                    <div className={styles.avatarPicker}>
+                        <button
+                            type="button"
+                            className={styles.avatarButton}
+                            onClick={() => fileInputRef.current?.click()}
+                            aria-label="Upload profile photo"
+                        >
+                            <img
+                                src={avatarPreview || '/default-avatar.svg'}
+                                alt=""
+                                className={styles.avatarImg}
+                            />
+                            <span className={styles.avatarOverlay}>
+                                <Camera size={18} strokeWidth={2} />
+                            </span>
+                        </button>
+                        <input
+                            ref={fileInputRef}
+                            type="file"
+                            accept="image/*"
+                            onChange={handleAvatarPick}
+                            style={{ display: 'none' }}
+                        />
+                        <span className={styles.avatarHint}>Add a profile photo</span>
+                    </div>
+
+                    <div className={styles.formGroup}>
+                        <label>Your name</label>
+                        <input
+                            type="text"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            placeholder="Full name"
+                            className={styles.inputField}
+                            maxLength={80}
+                        />
+                    </div>
+
+                    <div className={styles.formGroup}>
+                        <label>Username</label>
+                        <div className={styles.usernameInputWrap}>
+                            <span className={styles.usernamePrefix}>@</span>
+                            <input
+                                type="text"
+                                value={username}
+                                onChange={handleUsernameChange}
+                                placeholder="username"
+                                className={`${styles.inputField} ${styles.usernameInput} ${usernameError ? styles.inputError : ''}`}
+                                maxLength={30}
+                            />
+                        </div>
+                        {usernameError && <p className={styles.fieldError}>{usernameError}</p>}
+                    </div>
+
+                    <Button
+                        onClick={handleContinue}
+                        loading={saving}
+                        className="w-full mt-3 !rounded-full !py-3.5 !text-base"
+                    >
+                        Continue to Mitrata
+                    </Button>
+                </div>
+
+                <div className={styles.cardContainer_right}>
+                    <img src="/brand/orb-violet.png" alt="" className={styles.rightOrb} />
+                    <div className={styles.rightContent}>
+                        <span className={styles.rightLogo} role="img" aria-label="Mitrata" />
+                        <p>Friendship, first.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/onboarding/styles.module.css
+++ b/frontend/src/pages/onboarding/styles.module.css
@@ -1,0 +1,237 @@
+.container {
+    min-height: 100dvh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 40px 20px;
+    background: var(--mt-canvas);
+}
+
+.cardContainer {
+    width: 900px;
+    max-width: 100%;
+    min-height: 620px;
+    display: flex;
+    overflow: hidden;
+    border-radius: 28px;
+    border: 1px solid var(--mt-border);
+    background: var(--mt-surface);
+    box-shadow: var(--mt-shadow-lg);
+}
+
+.cardContainer_left {
+    flex: 1.15;
+    padding: 48px 44px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    justify-content: center;
+}
+
+.brandMark {
+    display: block;
+    width: 40px;
+    height: 40px;
+    margin-bottom: 14px;
+    background: var(--mt-grad);
+    -webkit-mask-image: url('/brand/mitrata-mark.png');
+    mask-image: url('/brand/mitrata-mark.png');
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    mask-position: center;
+}
+
+.heading {
+    font-family: var(--mt-font-display);
+    font-size: 1.7rem;
+    font-weight: 500;
+    letter-spacing: -0.02em;
+    color: var(--mt-ink);
+    margin: 0;
+}
+
+.subheading {
+    font-size: 0.9rem;
+    color: var(--mt-ink2);
+    max-width: 340px;
+    margin: 10px 0 26px;
+    line-height: 1.5;
+}
+
+.avatarPicker {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 24px;
+}
+
+.avatarButton {
+    position: relative;
+    width: 96px;
+    height: 96px;
+    border-radius: 50%;
+    padding: 0;
+    border: none;
+    cursor: pointer;
+    background: none;
+    flex-shrink: 0;
+}
+
+.avatarImg {
+    width: 100%;
+    height: 100%;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 3px solid var(--mt-border);
+    display: block;
+}
+
+.avatarOverlay {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--mt-grad);
+    color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 2px solid var(--mt-surface);
+}
+
+.avatarHint {
+    font-size: 0.8rem;
+    color: var(--mt-ink3);
+}
+
+.formGroup {
+    width: 100%;
+    max-width: 340px;
+    text-align: left;
+    margin-bottom: 14px;
+}
+
+.formGroup label {
+    display: block;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--mt-ink2);
+    margin-bottom: 6px;
+}
+
+.inputField {
+    width: 100%;
+    padding: 12px 16px;
+    border: 1px solid var(--mt-border);
+    background: var(--mt-canvas);
+    border-radius: 999px;
+    font-size: 0.95rem;
+    color: var(--mt-ink);
+    outline: none;
+    transition: border-color 0.18s;
+    box-sizing: border-box;
+}
+
+.inputField:focus {
+    border-color: var(--mt-accent, #0447ff);
+}
+
+.inputError {
+    border-color: var(--mt-danger);
+}
+
+.usernameInputWrap {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.usernamePrefix {
+    position: absolute;
+    left: 16px;
+    color: var(--mt-ink3);
+    font-size: 0.95rem;
+    pointer-events: none;
+}
+
+.usernameInput {
+    padding-left: 28px;
+}
+
+.fieldError {
+    font-size: 0.78rem;
+    color: var(--mt-danger);
+    margin: 6px 0 0;
+}
+
+.cardContainer_right {
+    flex: 0.85;
+    position: relative;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding: 2rem;
+    background: var(--mt-grad);
+    color: #fff;
+    font-size: 1rem;
+    font-weight: 500;
+    text-align: center;
+}
+
+.rightOrb {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: 0.55;
+    mix-blend-mode: overlay;
+    pointer-events: none;
+}
+
+.rightContent {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+}
+
+.rightLogo {
+    width: 120px;
+    height: 38px;
+    background: #fff;
+    -webkit-mask-image: url('/brand/mitrata-wordmark.png');
+    mask-image: url('/brand/mitrata-wordmark.png');
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    mask-position: center;
+}
+
+@media (max-width: 860px) {
+    .cardContainer {
+        flex-direction: column;
+        min-height: auto;
+    }
+
+    .cardContainer_right {
+        display: none;
+    }
+
+    .cardContainer_left {
+        padding: 40px 24px;
+    }
+}


### PR DESCRIPTION
## Summary
- New accounts (regular signup, Google, Apple) are prompted once, on first login, to set their name, pick a username, and upload a profile photo, on a single standalone page matching the login page's design.
- Existing accounts are unaffected: the new `onboarded` field defaults to `true` on hydration, verified against a real pre-existing account whose raw DB document has no `onboarded` field at all.
- Redirect gate lives once in `DashboardLayout` rather than duplicated across every login path (password, 2FA, Google, Apple).

## Test plan
- [x] Verified a real pre-existing user hydrates `onboarded: true` even though the raw DB document has no such field
- [x] Registered a throwaway test account via the live API, confirmed `onboarded: false`
- [x] Logged in, submitted name + username through the same endpoints the onboarding page uses, confirmed `onboarded: true` afterward
- [x] `npx next build` clean, `/onboarding` route present
- [x] Cleaned up the test account