### PR TITLE
Fix onboarding form reset bug + avatar wipe

### DIFF
--- a/frontend/src/config/redux/reducer/authReducer/index.js
+++ b/frontend/src/config/redux/reducer/authReducer/index.js
@@ -249,8 +249,11 @@ const authSlice = createSlice({
             .addCase(updateUserProfile.fulfilled, (state, action) => {
                 state.isLoading = false;
                 state.isSuccess = true;
-                // Update the local user object with the new Cloudinary path
-                if (state.user && state.user.userId) {
+                // Update the local user object with the new Cloudinary path —
+                // guarded because this endpoint is also used for
+                // bio/work/education updates that don't return a
+                // profilePicture, which would otherwise wipe out the real one.
+                if (state.user && state.user.userId && action.payload.profilePicture !== undefined) {
                     state.user.userId.profilePicture = action.payload.profilePicture;
                 }
                 state.message = "Profile picture updated!";
@@ -266,6 +269,7 @@ const authSlice = createSlice({
             })
             .addCase(updateAccountSettings.fulfilled, (state, action) => {
                 if (state.user?.userId) {
+                    if (action.payload.name !== undefined) state.user.userId.name = action.payload.name;
                     if (action.payload.username !== undefined) state.user.userId.username = action.payload.username;
                     if (action.payload.isPrivate !== undefined) state.user.userId.isPrivate = action.payload.isPrivate;
                     if (action.payload.pushEnabled !== undefined) state.user.userId.pushEnabled = action.payload.pushEnabled;

--- a/frontend/src/pages/onboarding/index.jsx
+++ b/frontend/src/pages/onboarding/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useDispatch, useSelector } from 'react-redux';
-import { getAboutUser, updateUserProfile, updateAccountSettings } from '@/config/redux/action/authAction';
+import { getAboutUser, updateAccountSettings } from '@/config/redux/action/authAction';
 import { clientServer } from '@/config';
 import { compressImage } from '@/utils/imageProcessing';
 import { useToast } from '@/Components/Toast';
@@ -31,6 +31,7 @@ export default function OnboardingPage() {
     const [avatarFile, setAvatarFile] = useState(null);
     const [avatarPreview, setAvatarPreview] = useState(null);
     const [saving, setSaving] = useState(false);
+    const initializedRef = useRef(false);
 
     useEffect(() => {
         if (typeof window === 'undefined') return;
@@ -50,6 +51,10 @@ export default function OnboardingPage() {
             router.replace('/dashboard');
             return;
         }
+        // Only pre-fill once — later store updates (e.g. this page's own
+        // submit) shouldn't stomp over what the user has already typed.
+        if (initializedRef.current) return;
+        initializedRef.current = true;
         setName(user.name || '');
         setUsername(user.username || '');
         setAvatarPreview(user.profilePicture || null);
@@ -99,14 +104,7 @@ export default function OnboardingPage() {
                 });
             }
 
-            const profileResult = await dispatch(updateUserProfile({ name: name.trim() }));
-            if (!updateUserProfile.fulfilled.match(profileResult)) {
-                toast.error(profileResult.payload?.message || 'Failed to save your name');
-                setSaving(false);
-                return;
-            }
-
-            const settingsResult = await dispatch(updateAccountSettings({ username, onboarded: true }));
+            const settingsResult = await dispatch(updateAccountSettings({ name: name.trim(), username, onboarded: true }));
             if (!updateAccountSettings.fulfilled.match(settingsResult)) {
                 setUsernameError(settingsResult.payload?.message || 'Username already taken');
                 setSaving(false);


### PR DESCRIPTION
## Summary
- The onboarding page's field-init effect reran on every Redux store update and reset the username/name/avatar fields back to stale values mid-submit — found via a live screenshot test where typing a new username then hitting Continue showed it snap back to the old value with the avatar wiped to a placeholder.
- Root cause: `updateUserProfile.fulfilled` unconditionally overwrote `profilePicture` from the response even when the response didn't include one (a name-only save), nulling it out; the onboarding page also reinitialized its local state on every `authState.user` change instead of once.
- Fix: guarded the profilePicture patch, gated the onboarding init effect to run once, and consolidated the onboarding save into a single `updateAccountSettings` call (confirmed it already accepts `name` alongside `username`/`onboarded`), removing the two-dispatch race entirely.

## Test plan
- [x] `npx next build` clean
- [x] Live screenshot test against production (Playwright): loaded onboarding as an authenticated new test account, confirmed layout on desktop + mobile viewports
- [x] Reproduced the reset bug live, applied fix, will re-verify after deploy